### PR TITLE
Add partial methods to codegen for migrations

### DIFF
--- a/src/EntityFramework/Migrations/Design/CSharpMigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/CSharpMigrationCodeGenerator.cs
@@ -98,7 +98,7 @@ namespace System.Data.Entity.Migrations.Design
                         @namespace, className, writer, "DbMigration", designer: false,
                         namespaces: GetNamespaces(operations));
 
-                    writer.WriteLine("public override void Up()");
+                    writer.WriteLine("partial void MigrateUp()");
                     writer.WriteLine("{");
                     writer.Indent++;
 
@@ -112,7 +112,7 @@ namespace System.Data.Entity.Migrations.Design
 
                     writer.WriteLine();
 
-                    writer.WriteLine("public override void Down()");
+                    writer.WriteLine("partial void MigrateDown()");
                     writer.WriteLine("{");
                     writer.Indent++;
 
@@ -188,11 +188,53 @@ namespace System.Data.Entity.Migrations.Design
                     writer.WriteLine();
                     WriteProperty("Target", "Resources.GetString(\"Target\")", writer);
 
+                    writer.WriteLine();
+                    WriteMigrateOverride("Up", writer);
+                    writer.WriteLine();
+                    WriteMigrateOverride("Down", writer);
+                    writer.WriteLine();
+
+                    WriteBeforeAfterPartials(writer);
+                    writer.WriteLine();
+
+
                     WriteClassEnd(@namespace, writer);
                 }
 
                 return stringWriter.ToString();
             }
+        }
+
+        private void WriteMigrateOverride(string UpOrDown, IndentedTextWriter writer)
+        {
+            writer.WriteLine("public override void {0}()", UpOrDown);
+            writer.WriteLine("{");
+            writer.Indent++;
+
+            writer.WriteLine("Before{0}();", UpOrDown);
+            writer.WriteLine("Migrate{0}();", UpOrDown);
+            writer.WriteLine("After{0}();", UpOrDown);
+
+            writer.Indent--;
+
+            writer.WriteLine("}");
+        }
+
+
+        /// <summary>
+        /// Adds declarations for user overrides in the migrations file.  Allows for manual tuning without walking over auto generated migrations.
+        /// </summary>
+        /// <param name="writer"></param>
+        protected virtual void WriteBeforeAfterPartials(IndentedTextWriter writer)
+        {
+
+            writer.WriteLine("partial void BeforeUp();");
+            writer.WriteLine("partial void MigrateUp();");
+            writer.WriteLine("partial void AfterUp();");
+            writer.WriteLine("partial void BeforeDown();");
+            writer.WriteLine("partial void MigrateDown();");
+            writer.WriteLine("partial void AfterDown();");
+
         }
 
         /// <summary>

--- a/src/EntityFramework/Migrations/Design/VisualBasicMigrationCodeGenerator.cs
+++ b/src/EntityFramework/Migrations/Design/VisualBasicMigrationCodeGenerator.cs
@@ -97,7 +97,7 @@ namespace System.Data.Entity.Migrations.Design
                         @namespace, className, writer, "Inherits DbMigration", designer: false,
                         namespaces: GetNamespaces(operations));
 
-                    writer.WriteLine("Public Overrides Sub Up()");
+                    writer.WriteLine("Public Sub MigrateUp()");
                     writer.Indent++;
 
                     operations
@@ -110,7 +110,7 @@ namespace System.Data.Entity.Migrations.Design
 
                     writer.WriteLine();
 
-                    writer.WriteLine("Public Overrides Sub Down()");
+                    writer.WriteLine("Public Sub MigrateDown()");
                     writer.Indent++;
 
                     operations
@@ -185,11 +185,52 @@ namespace System.Data.Entity.Migrations.Design
                     writer.WriteLine();
                     WriteProperty("Target", "Resources.GetString(\"Target\")", writer);
 
+                    writer.WriteLine();
+                    WriteMigrateOverride("Up", writer);
+                    writer.WriteLine();
+                    WriteMigrateOverride("Down", writer);
+                    writer.WriteLine();
+
+                    WriteBeforeAfterPartials(writer);
+                    writer.WriteLine();
+
                     WriteClassEnd(@namespace, writer);
                 }
 
                 return stringWriter.ToString();
             }
+        }
+
+        private void WriteMigrateOverride(string UpOrDown, IndentedTextWriter writer)
+        {
+            writer.WriteLine("Public Overrides Sub {0}()", UpOrDown);
+            writer.Indent++;
+
+            writer.WriteLine("Before{0}()", UpOrDown);
+            writer.WriteLine("Migrate{0}()", UpOrDown);
+            writer.WriteLine("After{0}()", UpOrDown);
+
+            writer.Indent--;
+
+            writer.WriteLine("End Sub");
+        }
+
+        private void WriteBeforeAfterPartials(IndentedTextWriter writer)
+        {
+
+            writer.WriteLine("Partial Private Sub BeforeUp()");
+            writer.WriteLine("End Sub");
+            writer.WriteLine("Partial Private Sub MigrateUp()");
+            writer.WriteLine("End Sub");
+            writer.WriteLine("Partial Private Sub AfterUp()");
+            writer.WriteLine("End Sub");
+            writer.WriteLine("Partial Private Sub BeforeDown()");
+            writer.WriteLine("End Sub");
+            writer.WriteLine("Partial Private Sub MigrateDown()");
+            writer.WriteLine("End Sub");
+            writer.WriteLine("Partial Private Sub AfterDown()");
+            writer.WriteLine("End Sub");
+
         }
 
         /// <summary>

--- a/test/EntityFramework/UnitTests/Migrations/Design/CSharpMigrationCodeGeneratorTests.cs
+++ b/test/EntityFramework/UnitTests/Migrations/Design/CSharpMigrationCodeGeneratorTests.cs
@@ -55,7 +55,7 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             CreateStoredProcedure(
                 ""Foo"",
@@ -70,7 +70,7 @@ namespace System.Data.Entity.Migrations.Design
             
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropStoredProcedure(""Foo"");
         }
@@ -116,7 +116,7 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AlterStoredProcedure(
                 ""Foo"",
@@ -131,7 +131,7 @@ namespace System.Data.Entity.Migrations.Design
             
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             throw new NotSupportedException(""" + Strings.ScaffoldSprocInDownNotSupported + @""");
         }
@@ -169,12 +169,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             RenameStoredProcedure(name: ""Foo"", newName: ""Bar"");
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             RenameStoredProcedure(name: ""Bar"", newName: ""Foo"");
         }
@@ -212,12 +212,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             RenameIndex(table: ""Foo"", name: ""Bar"", newName: ""Baz"");
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             RenameIndex(table: ""Foo"", name: ""Baz"", newName: ""Bar"");
         }
@@ -253,13 +253,13 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             DropStoredProcedure(""Foo"");
             DropTable(""Bar"");
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             CreateTable(
                 ""Bar"",
@@ -310,12 +310,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddColumn(""T"", ""C"", c => c.Decimal(defaultValue: 123.45m));
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropColumn(""T"", ""C"");
         }
@@ -365,12 +365,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddColumn(""T"", ""C"", c => c.Single(defaultValue: 123.45f));
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropColumn(""T"", ""C"");
         }
@@ -441,12 +441,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             DropPrimaryKey(""T"", name: ""PK"");
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             AddPrimaryKey(""T"", new[] { ""c1"", ""c2"" }, name: ""PK"");
         }
@@ -487,12 +487,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             DropPrimaryKey(""T"");
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             AddPrimaryKey(""T"", new[] { ""c1"", ""c2"" });
         }
@@ -534,12 +534,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddPrimaryKey(""T"", new[] { ""c1"", ""c2"" }, name: ""PK"");
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropPrimaryKey(""T"", name: ""PK"");
         }
@@ -580,12 +580,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddPrimaryKey(""T"", new[] { ""c1"", ""c2"" });
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropPrimaryKey(""T"");
         }
@@ -628,12 +628,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddPrimaryKey(""T"", new[] { ""c1"", ""c2"" }, name: ""PK"", clustered: false);
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropPrimaryKey(""T"", name: ""PK"");
         }
@@ -676,12 +676,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddForeignKey(""Orders"", ""CustomerId"", ""Customers"", ""Id"", cascadeDelete: true);
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropForeignKey(""Orders"", ""CustomerId"", ""Customers"");
         }
@@ -725,12 +725,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddForeignKey(""Orders"", new[] { ""CustomerId1"", ""CustomerId2"" }, ""Customers"", new[] { ""Id1"", ""Id2"" });
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropForeignKey(""Orders"", new[] { ""CustomerId1"", ""CustomerId2"" }, ""Customers"");
         }
@@ -764,12 +764,12 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             DropColumn(""Customers"", ""Foo"");
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
         }
     }
@@ -808,7 +808,7 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             CreateTable(
                 ""Customers"",
@@ -819,7 +819,7 @@ namespace System.Data.Entity.Migrations.Design
             
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropTable(""Customers"");
         }
@@ -885,7 +885,7 @@ namespace System.Data.Entity.Migrations.Design
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             CreateTable(
                 ""Customers"",
@@ -900,7 +900,7 @@ namespace System.Data.Entity.Migrations.Design
             
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropIndex(""Customers"", new[] { ""Blog.Id"" });
             DropForeignKey(""Customers"", ""Blog.Id"", ""Blogs"");
@@ -939,6 +939,28 @@ namespace Foo
         {
             get { return Resources.GetString(""Target""); }
         }
+        
+        public override void Up()
+        {
+            BeforeUp();
+            MigrateUp();
+            AfterUp();
+        }
+        
+        public override void Down()
+        {
+            BeforeDown();
+            MigrateDown();
+            AfterDown();
+        }
+        
+        partial void BeforeUp();
+        partial void MigrateUp();
+        partial void AfterUp();
+        partial void BeforeDown();
+        partial void MigrateDown();
+        partial void AfterDown();
+        
     }
 }
 ",
@@ -995,7 +1017,7 @@ namespace Foo
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             CreateTable(
                 ""Customers"",
@@ -1008,7 +1030,7 @@ namespace Foo
             
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropIndex(""Customers"", ""MyIndex"");
             DropTable(""Customers"");
@@ -1051,12 +1073,12 @@ namespace Foo
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             CreateIndex(""MyTable"", ""MyColumn"", unique: true, clustered: true, name: ""MyIndex"");
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropIndex(""MyTable"", ""MyIndex"");
         }
@@ -1088,12 +1110,12 @@ namespace Foo
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             DropTable(""Customers"");
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
         }
     }
@@ -1124,12 +1146,12 @@ namespace Foo
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             MoveStoredProcedure(name: ""Insert_Customers"", newSchema: ""foo"");
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             MoveStoredProcedure(name: ""foo.Insert_Customers"", newSchema: null);
         }
@@ -1206,6 +1228,28 @@ namespace Foo
         {
             get { return Resources.GetString(""Target""); }
         }
+        
+        public override void Up()
+        {
+            BeforeUp();
+            MigrateUp();
+            AfterUp();
+        }
+        
+        public override void Down()
+        {
+            BeforeDown();
+            MigrateDown();
+            AfterDown();
+        }
+        
+        partial void BeforeUp();
+        partial void MigrateUp();
+        partial void AfterUp();
+        partial void BeforeDown();
+        partial void MigrateDown();
+        partial void AfterDown();
+        
     }
 }
 ",
@@ -1246,12 +1290,12 @@ namespace Foo
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddColumn(""T"", ""C"", c => c.Geography(nullable: false, defaultValue: DbGeography.FromText(""POINT (6 7)"", 4326)));
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropColumn(""T"", ""C"");
         }
@@ -1292,12 +1336,12 @@ namespace Foo
     
     public partial class Bar : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddColumn(""T"", ""C"", c => c.Geometry(nullable: false, defaultValue: DbGeometry.FromText(""POINT (8 9)"", 0)));
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropColumn(""T"", ""C"");
         }
@@ -1346,6 +1390,28 @@ public sealed partial class Bar : IMigrationMetadata
     {
         get { return Resources.GetString(""Target""); }
     }
+    
+    public override void Up()
+    {
+        BeforeUp();
+        MigrateUp();
+        AfterUp();
+    }
+    
+    public override void Down()
+    {
+        BeforeDown();
+        MigrateDown();
+        AfterDown();
+    }
+    
+    partial void BeforeUp();
+    partial void MigrateUp();
+    partial void AfterUp();
+    partial void BeforeDown();
+    partial void MigrateDown();
+    partial void AfterDown();
+    
 }
 ",
                 generatedMigration.DesignerCode);
@@ -1359,11 +1425,11 @@ using System.Data.Entity.Migrations;
 
 public partial class Bar : DbMigration
 {
-    public override void Up()
+    partial void MigrateUp()
     {
     }
     
-    public override void Down()
+    partial void MigrateDown()
     {
     }
 }
@@ -1412,7 +1478,7 @@ public partial class Bar : DbMigration
     
     public partial class MyMigration : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AlterColumn(""MyTable"", ""MyColumn"", c => c.Int(fixedLength: true,
                 annotations: new Dictionary<string, AnnotationValues>
@@ -1456,7 +1522,7 @@ public partial class Bar : DbMigration
                 }));
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
         }
     }
@@ -1520,7 +1586,7 @@ public partial class Bar : DbMigration
     
     public partial class MyMigration : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AlterColumn(""MyTable"", ""MyColumn"", c => c.Int(
                 annotations: new Dictionary<string, AnnotationValues>
@@ -1532,7 +1598,7 @@ public partial class Bar : DbMigration
                 }));
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             AlterColumn(""MyTable"", ""MyColumn"", c => c.Int(
                 annotations: new Dictionary<string, AnnotationValues>
@@ -1583,7 +1649,7 @@ public partial class Bar : DbMigration
     
     public partial class MyMigration : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddColumn(""MyTable"", ""MyColumn"", c => c.String(fixedLength: true,
                 annotations: new Dictionary<string, AnnotationValues>
@@ -1599,7 +1665,7 @@ public partial class Bar : DbMigration
                 }));
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropColumn(""MyTable"", ""MyColumn"",
                 removedAnnotations: new Dictionary<string, object>
@@ -1654,7 +1720,7 @@ public partial class Bar : DbMigration
     
     public partial class MyMigration : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AddColumn(""MyTable"", ""MyColumn"", c => c.String(fixedLength: true,
                 annotations: new Dictionary<string, AnnotationValues>
@@ -1666,7 +1732,7 @@ public partial class Bar : DbMigration
                 }));
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropColumn(""MyTable"", ""MyColumn"",
                 removedAnnotations: new Dictionary<string, object>
@@ -1745,7 +1811,7 @@ public partial class Bar : DbMigration
     
     public partial class MyMigration : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             CreateTable(
                 ""Customers"",
@@ -1781,7 +1847,7 @@ public partial class Bar : DbMigration
             
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             DropTable(""Customers"",
                 removedAnnotations: new Dictionary<string, object>
@@ -1880,7 +1946,7 @@ public partial class Bar : DbMigration
     
     public partial class MyMigration : DbMigration
     {
-        public override void Up()
+        partial void MigrateUp()
         {
             AlterTableAnnotations(
                 ""Customers"",
@@ -1925,7 +1991,7 @@ public partial class Bar : DbMigration
             
         }
         
-        public override void Down()
+        partial void MigrateDown()
         {
             AlterTableAnnotations(
                 ""Customers"",

--- a/test/EntityFramework/UnitTests/Migrations/Design/VisualBasicMigrationCodeGeneratorTests.cs
+++ b/test/EntityFramework/UnitTests/Migrations/Design/VisualBasicMigrationCodeGeneratorTests.cs
@@ -56,7 +56,7 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             CreateStoredProcedure(
                 ""Foo"",
                 Function(p) New With
@@ -70,7 +70,7 @@ Namespace Foo
             
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropStoredProcedure(""Foo"")
         End Sub
     End Class
@@ -116,7 +116,7 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AlterStoredProcedure(
                 ""Foo"",
                 Function(p) New With
@@ -130,7 +130,7 @@ Namespace Foo
             
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             Throw New NotSupportedException(""" + Strings.ScaffoldSprocInDownNotSupported + @""")
         End Sub
     End Class
@@ -168,11 +168,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             RenameIndex(table := ""Foo"", name := ""Bar"", newName := ""Baz"")
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             RenameIndex(table := ""Foo"", name := ""Baz"", newName := ""Bar"")
         End Sub
     End Class
@@ -210,11 +210,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             RenameStoredProcedure(name := ""Foo"", newName := ""Bar"")
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             RenameStoredProcedure(name := ""Bar"", newName := ""Foo"")
         End Sub
     End Class
@@ -250,12 +250,12 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             DropStoredProcedure(""Foo"")
             DropTable(""Bar"")
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             CreateTable(
                 ""Bar"",
                 Function(c) New With
@@ -306,11 +306,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddColumn(""T"", ""C"", Function(c) c.Decimal(defaultValue := 123.45D))
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropColumn(""T"", ""C"")
         End Sub
     End Class
@@ -360,11 +360,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddColumn(""T"", ""C"", Function(c) c.Single(defaultValue := 123.45F))
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropColumn(""T"", ""C"")
         End Sub
     End Class
@@ -435,11 +435,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             DropPrimaryKey(""T"", name := ""PK"")
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             AddPrimaryKey(""T"", New String() { ""c1"", ""c2"" }, name := ""PK"")
         End Sub
     End Class
@@ -480,11 +480,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             DropPrimaryKey(""T"")
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             AddPrimaryKey(""T"", New String() { ""c1"", ""c2"" })
         End Sub
     End Class
@@ -526,11 +526,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddPrimaryKey(""T"", New String() { ""c1"", ""c2"" }, name := ""PK"")
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropPrimaryKey(""T"", name := ""PK"")
         End Sub
     End Class
@@ -571,11 +571,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddPrimaryKey(""T"", New String() { ""c1"", ""c2"" })
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropPrimaryKey(""T"")
         End Sub
     End Class
@@ -618,11 +618,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddPrimaryKey(""T"", New String() { ""c1"", ""c2"" }, name := ""PK"", clustered := False)
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropPrimaryKey(""T"", name := ""PK"")
         End Sub
     End Class
@@ -665,11 +665,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddForeignKey(""Orders"", ""CustomerId"", ""Customers"", ""Id"", cascadeDelete := True)
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropForeignKey(""Orders"", ""CustomerId"", ""Customers"")
         End Sub
     End Class
@@ -713,11 +713,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddForeignKey(""Orders"", New String() { ""CustomerId1"", ""CustomerId2"" }, ""Customers"", New String() { ""Id1"", ""Id2"" })
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropForeignKey(""Orders"", New String() { ""CustomerId1"", ""CustomerId2"" }, ""Customers"")
         End Sub
     End Class
@@ -751,11 +751,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             DropColumn(""Customers"", ""Foo"")
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
         End Sub
     End Class
 End Namespace
@@ -794,7 +794,7 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             CreateTable(
                 ""Customers"",
                 Function(c) New With
@@ -804,7 +804,7 @@ Namespace Foo
             
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropTable(""Customers"")
         End Sub
     End Class
@@ -870,7 +870,7 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             CreateTable(
                 ""Customers"",
                 Function(c) New With
@@ -884,7 +884,7 @@ Namespace Foo
             
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropIndex(""Customers"", New String() { ""Blog.Id"" })
             DropForeignKey(""Customers"", ""Blog.Id"", ""Blogs"")
             DropTable(""Customers"")
@@ -925,6 +925,32 @@ Namespace Foo
                 Return Resources.GetString(""Target"")
             End Get
         End Property
+        
+        Public Overrides Sub Up()
+            BeforeUp()
+            MigrateUp()
+            AfterUp()
+        End Sub
+        
+        Public Overrides Sub Down()
+            BeforeDown()
+            MigrateDown()
+            AfterDown()
+        End Sub
+        
+        Partial Private Sub BeforeUp()
+        End Sub
+        Partial Private Sub MigrateUp()
+        End Sub
+        Partial Private Sub AfterUp()
+        End Sub
+        Partial Private Sub BeforeDown()
+        End Sub
+        Partial Private Sub MigrateDown()
+        End Sub
+        Partial Private Sub AfterDown()
+        End Sub
+        
     End Class
 End Namespace
 ",
@@ -982,7 +1008,7 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             CreateTable(
                 ""Customers"",
                 Function(c) New With
@@ -994,7 +1020,7 @@ Namespace Foo
             
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropIndex(""Customers"", ""MyIndex"")
             DropTable(""Customers"")
         End Sub
@@ -1037,11 +1063,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             CreateIndex(""MyTable"", ""MyColumn"", unique := True, clustered := True, name := ""MyIndex"")
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropIndex(""MyTable"", ""MyIndex"")
         End Sub
     End Class
@@ -1073,11 +1099,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             DropTable(""Customers"")
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
         End Sub
     End Class
 End Namespace
@@ -1109,11 +1135,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             MoveStoredProcedure(name := ""Insert_Customers"", newSchema := ""foo"")
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             MoveStoredProcedure(name := ""foo.Insert_Customers"", newSchema := Nothing)
         End Sub
     End Class
@@ -1192,6 +1218,32 @@ Namespace Foo
                 Return Resources.GetString(""Target"")
             End Get
         End Property
+        
+        Public Overrides Sub Up()
+            BeforeUp()
+            MigrateUp()
+            AfterUp()
+        End Sub
+        
+        Public Overrides Sub Down()
+            BeforeDown()
+            MigrateDown()
+            AfterDown()
+        End Sub
+        
+        Partial Private Sub BeforeUp()
+        End Sub
+        Partial Private Sub MigrateUp()
+        End Sub
+        Partial Private Sub AfterUp()
+        End Sub
+        Partial Private Sub BeforeDown()
+        End Sub
+        Partial Private Sub MigrateDown()
+        End Sub
+        Partial Private Sub AfterDown()
+        End Sub
+        
     End Class
 End Namespace
 ",
@@ -1233,11 +1285,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddColumn(""T"", ""C"", Function(c) c.Geography(nullable := False, defaultValue := DbGeography.FromText(""POINT (6 7)"", 4326)))
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropColumn(""T"", ""C"")
         End Sub
     End Class
@@ -1278,11 +1330,11 @@ Namespace Foo
     Public Partial Class Bar
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddColumn(""T"", ""C"", Function(c) c.Geometry(nullable := False, defaultValue := DbGeometry.FromText(""POINT (8 9)"", 0)))
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropColumn(""T"", ""C"")
         End Sub
     End Class
@@ -1334,6 +1386,32 @@ Public NotInheritable Partial Class Bar
             Return Resources.GetString(""Target"")
         End Get
     End Property
+    
+    Public Overrides Sub Up()
+        BeforeUp()
+        MigrateUp()
+        AfterUp()
+    End Sub
+    
+    Public Overrides Sub Down()
+        BeforeDown()
+        MigrateDown()
+        AfterDown()
+    End Sub
+    
+    Partial Private Sub BeforeUp()
+    End Sub
+    Partial Private Sub MigrateUp()
+    End Sub
+    Partial Private Sub AfterUp()
+    End Sub
+    Partial Private Sub BeforeDown()
+    End Sub
+    Partial Private Sub MigrateDown()
+    End Sub
+    Partial Private Sub AfterDown()
+    End Sub
+    
 End Class
 ",
                 generatedMigration.DesignerCode);
@@ -1349,10 +1427,10 @@ Imports Microsoft.VisualBasic
 Public Partial Class Bar
     Inherits DbMigration
 
-    Public Overrides Sub Up()
+    Public Sub MigrateUp()
     End Sub
     
-    Public Overrides Sub Down()
+    Public Sub MigrateDown()
     End Sub
 End Class
 ",
@@ -1401,7 +1479,7 @@ Namespace MyNamespace
     Public Partial Class MyMigration
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AlterColumn(""MyTable"", ""MyColumn"", Function(c) c.Int(fixedLength := true,
                 annotations := New Dictionary(Of String, AnnotationValues)() From _
                 {
@@ -1444,7 +1522,7 @@ Namespace MyNamespace
                 }))
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
         End Sub
     End Class
 End Namespace
@@ -1508,7 +1586,7 @@ Namespace MyNamespace
     Public Partial Class MyMigration
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AlterColumn(""MyTable"", ""MyColumn"", Function(c) c.Int(
                 annotations := New Dictionary(Of String, AnnotationValues)() From _
                 {
@@ -1519,7 +1597,7 @@ Namespace MyNamespace
                 }))
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             AlterColumn(""MyTable"", ""MyColumn"", Function(c) c.Int(
                 annotations := New Dictionary(Of String, AnnotationValues)() From _
                 {
@@ -1570,7 +1648,7 @@ Namespace MyNamespace
     Public Partial Class MyMigration
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddColumn(""MyTable"", ""MyColumn"", Function(c) c.String(fixedLength := true,
                 annotations := New Dictionary(Of String, AnnotationValues)() From _
                 {
@@ -1585,7 +1663,7 @@ Namespace MyNamespace
                 }))
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropColumn(""MyTable"", ""MyColumn"",
                 removedAnnotations := New Dictionary(Of String, Object)() From _
                 {
@@ -1640,7 +1718,7 @@ Namespace MyNamespace
     Public Partial Class MyMigration
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AddColumn(""MyTable"", ""MyColumn"", Function(c) c.String(fixedLength := true,
                 annotations := New Dictionary(Of String, AnnotationValues)() From _
                 {
@@ -1651,7 +1729,7 @@ Namespace MyNamespace
                 }))
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropColumn(""MyTable"", ""MyColumn"",
                 removedAnnotations := New Dictionary(Of String, Object)() From _
                 {
@@ -1730,7 +1808,7 @@ Namespace MyNamespace
     Public Partial Class MyMigration
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             CreateTable(
                 ""Customers"",
                 Function(c) New With
@@ -1765,7 +1843,7 @@ Namespace MyNamespace
             
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             DropTable(""Customers"",
                 removedAnnotations := New Dictionary(Of String, Object)() From _
                 {
@@ -1864,7 +1942,7 @@ Namespace MyNamespace
     Public Partial Class MyMigration
         Inherits DbMigration
     
-        Public Overrides Sub Up()
+        Public Sub MigrateUp()
             AlterTableAnnotations(
                 ""Customers"",
                 Function(c) New With
@@ -1908,7 +1986,7 @@ Namespace MyNamespace
             
         End Sub
         
-        Public Overrides Sub Down()
+        Public Sub MigrateDown()
             AlterTableAnnotations(
                 ""Customers"",
                 Function(c) New With


### PR DESCRIPTION
After working with and evolving migrations as I develop, I found that the current system is too eagerly walking over potentially hand coded migration code.  Developers are encouraged to use `Add-Migration` and then told again to use `Add-Migration -force` to update a migration.

This helps to deal with this issue, by creating partial methods that can be implemented in a separate file that is not touched by the Add-Migration process, even using -force

- [x] CSharp code gen
- [x] VB code gen

A practical implementation to Issue #684