### PR TITLE
Fix for Feedback Issue 964348 - use %% syntax for referencing VSAPPIDDIR env var

### DIFF
--- a/src/EFTools/EntityDesign/TextTemplates/Includes/EF6.Utility.CS.ttinclude
+++ b/src/EFTools/EntityDesign/TextTemplates/Includes/EF6.Utility.CS.ttinclude
@@ -4,8 +4,8 @@
 <#@ assembly name="System.Xml" #>
 <#@ assembly name="System.Xml.Linq"#>
 <#@ assembly name="EnvDTE"#>
-<#@ assembly name="$(VSAPPIDDIR)EntityFramework.dll" #>
-<#@ assembly name="$(VSAPPIDDIR)Microsoft.Data.Entity.Design.dll" #>
+<#@ assembly name="%VSAPPIDDIR%EntityFramework.dll" #>
+<#@ assembly name="%VSAPPIDDIR%Microsoft.Data.Entity.Design.dll" #>
 <#@ import namespace="System" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.IO" #>

--- a/src/EFTools/EntityDesign/TextTemplates/Includes/EF6.Utility.VB.ttinclude
+++ b/src/EFTools/EntityDesign/TextTemplates/Includes/EF6.Utility.VB.ttinclude
@@ -4,8 +4,8 @@
 <#@ assembly name="System.Xml" #>
 <#@ assembly name="System.Xml.Linq"#>
 <#@ assembly name="EnvDTE"#>
-<#@ assembly name="$(VSAPPIDDIR)EntityFramework.dll" #>
-<#@ assembly name="$(VSAPPIDDIR)Microsoft.Data.Entity.Design.dll" #>
+<#@ assembly name="%VSAPPIDDIR%EntityFramework.dll" #>
+<#@ assembly name="%VSAPPIDDIR%Microsoft.Data.Entity.Design.dll" #>
 <#@ import namespace="System" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.IO" #>

--- a/src/EFTools/EntityDesign/TextTemplates/SsdlToSql10.tt
+++ b/src/EFTools/EntityDesign/TextTemplates/SsdlToSql10.tt
@@ -10,10 +10,10 @@
 // macros and environment variables into account (e.g. $(ProjectDir), VERSIONED_VSCOMNTOOLS_ENV_VAR etc.)
 #>
 <#@ assembly name="System.Core" #>
-<#@ assembly name="$(VSAPPIDDIR)Microsoft.Data.Entity.Design.DatabaseGeneration.dll"#>
-<#@ assembly name="$(VSAPPIDDIR)EntityFramework.dll"#>
-<#@ assembly name="$(VSAPPIDDIR)EntityFramework.SqlServer.dll" #>
-<#@ assembly name="$(VSAPPIDDIR)EntityFramework.SqlServerCompact.dll" #>
+<#@ assembly name="%VSAPPIDDIR%Microsoft.Data.Entity.Design.DatabaseGeneration.dll"#>
+<#@ assembly name="%VSAPPIDDIR%EntityFramework.dll"#>
+<#@ assembly name="%VSAPPIDDIR%EntityFramework.SqlServer.dll" #>
+<#@ assembly name="%VSAPPIDDIR%EntityFramework.SqlServerCompact.dll" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
 <#@ import namespace="System.Collections.Generic" #>


### PR DESCRIPTION
We were previously using the $(VSAPPIDDIR) syntax. After discussion with the T4 team we need to use the %VSAPPIDDIR% syntax instead.