### PR TITLE
Issue #561: Cast error, not enough information (add column info)

### DIFF
--- a/src/EntityFramework/Core/Common/EntityUtil.cs
+++ b/src/EntityFramework/Core/Common/EntityUtil.cs
@@ -327,6 +327,25 @@ namespace System.Data.Entity.Core
             }
         }
 
+        internal static InvalidOperationException ValueInvalidCast(Type valueType, Type destinationType, string columnName)
+        {
+            DebugCheck.NotNull(valueType);
+            DebugCheck.NotNull(destinationType);
+            if (destinationType.IsValueType()
+                && destinationType.IsGenericType()
+                && (typeof(Nullable<>) == destinationType.GetGenericTypeDefinition()))
+            {
+                return new InvalidOperationException(
+                    Strings.Materializer_InvalidColumnCastNullable(
+                        valueType, destinationType.GetGenericArguments()[0], columnName));
+            }
+            else
+            {
+                return new InvalidOperationException(
+                    Strings.Materializer_InvalidColumnCastReference(
+                        valueType, destinationType, columnName));
+            }
+        }
         internal static InvalidOperationException ValueInvalidCast(Type valueType, Type destinationType)
         {
             DebugCheck.NotNull(valueType);

--- a/src/EntityFramework/Core/Common/internal/materialization/CodeGenEmitter.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/CodeGenEmitter.cs
@@ -291,6 +291,41 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
         }
 
         // <summary>
+        // Create expression that guarantees the input expression is of the specified
+        // type; no Convert is added if the expression is already of the same type.
+        // Add columnName for more cast failed information.
+        // Internal because it is called from the TranslatorResult.
+        // </summary>
+        internal static Expression Emit_EnsureType(Expression input, Type type, string columnName)
+        {
+            var result = input;
+            if (input.Type != type
+                && !typeof(IEntityWrapper).IsAssignableFrom(input.Type))
+            {
+                if (type.IsAssignableFrom(input.Type))
+                {
+                    // simple convert, just to make sure static type checks succeed
+                    result = Expression.Convert(input, type);
+                }
+                else
+                {
+                    // user is asking for the 'wrong' type... add exception handling
+                    // in case of failure
+                    try
+                    {
+                        var checkedConvertMethod = CodeGenEmitter_CheckedConvert.MakeGenericMethod(input.Type, type);
+                        result = Expression.Call(checkedConvertMethod, input);
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        throw new InvalidOperationException(Strings.Materializer_InvalidColumnCastMessage(columnName, e.Message), e);
+                    }
+                }
+            }
+            return result;
+        }
+
+        // <summary>
         // Uses Emit_EnsureType and then wraps the result in an IEntityWrapper instance.
         // </summary>
         // <param name="input"> The expression that creates the entity to be wrapped </param>

--- a/src/EntityFramework/Core/Common/internal/materialization/shaper.cs
+++ b/src/EntityFramework/Core/Common/internal/materialization/shaper.cs
@@ -964,7 +964,8 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                             var resultType = null == untypedResult ? null : untypedResult.GetType();
                             if (!typeof(T).IsAssignableFrom(resultType))
                             {
-                                throw CreateWrongTypeException(resultType);
+                                var columnName = reader.GetName(ordinal);
+                                throw CreateWrongTypeException(resultType, columnName);
                             }
                         }
                         throw;
@@ -983,7 +984,7 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
             // Creates the exception thrown when the reader returns a value with
             // an incompatible type.
             // </summary>
-            protected abstract Exception CreateWrongTypeException(Type resultType);
+            protected abstract Exception CreateWrongTypeException(Type resultType, string columnName);
         }
 
         private class ColumnErrorHandlingValueReader<TColumn> : ErrorHandlingValueReader<TColumn>
@@ -1003,9 +1004,9 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                 return new InvalidOperationException(Strings.Materializer_NullReferenceCast(typeof(TColumn)));
             }
 
-            protected override Exception CreateWrongTypeException(Type resultType)
+            protected override Exception CreateWrongTypeException(Type resultType, string columnName)
             {
-                return EntityUtil.ValueInvalidCast(resultType, typeof(TColumn));
+                return EntityUtil.ValueInvalidCast(resultType, typeof(TColumn), columnName);
             }
         }
 
@@ -1037,12 +1038,12 @@ namespace System.Data.Entity.Core.Common.Internal.Materialization
                         _typeName, _propertyName, "null"));
             }
 
-            protected override Exception CreateWrongTypeException(Type resultType)
+            protected override Exception CreateWrongTypeException(Type resultType, string columnName)
             {
                 return new InvalidOperationException(
                     Strings.Materializer_SetInvalidValue(
                         Nullable.GetUnderlyingType(typeof(TProperty)) ?? typeof(TProperty),
-                        _typeName, _propertyName, resultType));
+                        _typeName, _propertyName ?? columnName, resultType));
             }
         }
 

--- a/src/EntityFramework/Properties/Resources.cs
+++ b/src/EntityFramework/Properties/Resources.cs
@@ -7119,11 +7119,35 @@ namespace System.Data.Entity.Resources
         }
 
         // <summary>
+        // A string like "The specified cast from a materialized column '{0}' with type '{1}' to the '{2}' type is not valid."
+        // </summary>
+        internal static string Materializer_InvalidColumnCastReference(object p0, object p1, object p2)
+        {
+            return EntityRes.GetString(EntityRes.Materializer_InvalidColumnCastReference, p0, p1, p2);
+        }
+
+        // <summary>
+        // A string like "The column with the name '{0}' conversion failed, {1}"
+        // </summary>
+        internal static string Materializer_InvalidColumnCastMessage(object p0, object p1)
+        {
+            return EntityRes.GetString(EntityRes.Materializer_InvalidColumnCastMessage, p0, p1);
+        }
+
+        // <summary>
         // A string like "The specified cast from a materialized '{0}' type to a nullable '{1}' type is not valid."
         // </summary>
         internal static string Materializer_InvalidCastNullable(object p0, object p1)
         {
             return EntityRes.GetString(EntityRes.Materializer_InvalidCastNullable, p0, p1);
+        }
+
+        // <summary>
+        // A string like "The specified cast from a materialized column '{0}' with type '{1}' to a nullable '{2}' type is not valid."
+        // </summary>
+        internal static string Materializer_InvalidColumnCastNullable(object p0, object p1, object p2)
+        {
+            return EntityRes.GetString(EntityRes.Materializer_InvalidColumnCastNullable, p0, p1, p2);
         }
 
         // <summary>
@@ -16622,7 +16646,10 @@ namespace System.Data.Entity.Resources
         internal const string Materializer_PropertyIsNotNullableWithName = "Materializer_PropertyIsNotNullableWithName";
         internal const string Materializer_SetInvalidValue = "Materializer_SetInvalidValue";
         internal const string Materializer_InvalidCastReference = "Materializer_InvalidCastReference";
+        internal const string Materializer_InvalidColumnCastReference = "Materializer_InvalidColumnCastReference";
+        internal const string Materializer_InvalidColumnCastMessage = "Materializer_InvalidColumnCastMessage";
         internal const string Materializer_InvalidCastNullable = "Materializer_InvalidCastNullable";
+        internal const string Materializer_InvalidColumnCastNullable = "Materializer_InvalidColumnCastNullable";
         internal const string Materializer_NullReferenceCast = "Materializer_NullReferenceCast";
         internal const string Materializer_RecyclingEntity = "Materializer_RecyclingEntity";
         internal const string Materializer_AddedEntityAlreadyExists = "Materializer_AddedEntityAlreadyExists";

--- a/src/EntityFramework/Properties/Resources.resx
+++ b/src/EntityFramework/Properties/Resources.resx
@@ -2940,8 +2940,17 @@
   <data name="Materializer_InvalidCastReference" xml:space="preserve">
     <value>The specified cast from a materialized '{0}' type to the '{1}' type is not valid.</value>
   </data>
+  <data name="Materializer_InvalidColumnCastReference" xml:space="preserve">
+    <value>The specified cast from a materialized column '{0}' with type '{1}' to the '{2}' type is not valid.</value>
+  </data>
+  <data name="Materializer_InvalidColumnCastMessage" xml:space="preserve">
+    <value>The column with the name '{0}' conversion failed, {1}</value>
+  </data>
   <data name="Materializer_InvalidCastNullable" xml:space="preserve">
     <value>The specified cast from a materialized '{0}' type to a nullable '{1}' type is not valid.</value>
+  </data>
+  <data name="Materializer_InvalidColumnCastNullable" xml:space="preserve">
+    <value>The specified cast from a materialized column '{0}' with type '{1}' to a nullable '{2}' type is not valid.</value>
   </data>
   <data name="Materializer_NullReferenceCast" xml:space="preserve">
     <value>The cast to value type '{0}' failed because the materialized value is null. Either the result type's generic parameter or the query must use a nullable type.</value>

--- a/test/FunctionalTests/ProductivityApi/DbSqlQueryTests.cs
+++ b/test/FunctionalTests/ProductivityApi/DbSqlQueryTests.cs
@@ -614,8 +614,8 @@ namespace ProductivityApiTests
                 var query = context.Database.SqlQuery<UnMappedProduct>("select * from Categories");
 
                 Assert.Throws<InvalidOperationException>(() => query.ToList()).ValidateMessage(
-                    "Materializer_InvalidCastReference", "System.String",
-                    "System.Int32");
+                    "Materializer_InvalidColumnCastReference", "System.String",
+                    "System.Int32", "Id");
             }
         }
 
@@ -628,8 +628,8 @@ namespace ProductivityApiTests
                 var query = context.Database.SqlQuery<UnMappedProduct>("select * from Categories").AsStreaming();
 
                 Assert.Throws<InvalidOperationException>(() => query.ToList()).ValidateMessage(
-                    "Materializer_InvalidCastReference", "System.String",
-                    "System.Int32");
+                    "Materializer_InvalidColumnCastReference", "System.String",
+                    "System.Int32", "Id");
             }
         }
 #pragma warning restore 612, 618
@@ -647,8 +647,8 @@ namespace ProductivityApiTests
                     () => ExceptionHelpers.UnwrapAggregateExceptions(
                         () =>
                             query.ToListAsync().Result)).ValidateMessage(
-                                "Materializer_InvalidCastReference", "System.String",
-                                "System.Int32");
+                                "Materializer_InvalidColumnCastReference", "System.String",
+                                "System.Int32", "Id");
             }
         }
 
@@ -664,8 +664,8 @@ namespace ProductivityApiTests
                     () => ExceptionHelpers.UnwrapAggregateExceptions(
                         () =>
                             query.ToListAsync().Result)).ValidateMessage(
-                                "Materializer_InvalidCastReference", "System.String",
-                                "System.Int32");
+                                "Materializer_InvalidColumnCastReference", "System.String",
+                                "System.Int32", "Id");
             }
         }
 #pragma warning restore 612, 618


### PR DESCRIPTION
Calling stored procedures from entity framework involves type mapping.
Very often procedure result schema and code-behind class are not in sync.
Debugging this problem is a mess, we even had to include EF source code to understand problematic columns.
Error example:
```
The specified cast from a materialized 'System.Int32' type to the 'System.Double' type is not valid.
```
This PR aims to add more info to such errors so the exception would contain:
```
The specified cast from a materialized column 'column0' with type 'System.Int32' to the 'System.Double' type is not valid.
```
Notice column name present in resulting error.

Examples of uncertainty:
https://stackoverflow.com/questions/22390610/the-specified-cast-from-a-materialized-system-int32-type-to-the-system-string
https://stackoverflow.com/questions/32264382/the-specified-cast-from-a-materialized-system-int32-type-to-the-system-double
https://stackoverflow.com/questions/23914429/the-specified-cast-from-a-materialized-system-datetime-type-to-the-system-str

Although the referenced issue #561 is Closed, the PR that solved that issue was not merged (because of missing tests).

This PR include changes from #771 with some additional error handling for Shaper class (specifically GetColumnValueWithErrorHandling method) also contains tests for target cases.