### PR TITLE
[release/6.4] Move SDL validation to ringed release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,9 +9,6 @@ variables:
     value: true
   - name: _DotNetArtifactsCategory
     value: ASPNETENTITYFRAMEWORK6
-  # used for post-build phases, internal builds only
-  - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-    - group: DotNet-EFCore-SDLValidation-Params
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
     - group: DotNet-MSRC-Storage
     - name: _InternalRuntimeDownloadArgs
@@ -117,17 +114,3 @@ stages:
       # Symbol validation isn't being very reliable lately. This should be enabled back
       # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false 
-      # This is to enable SDL runs part of Post-Build Validation Stage
-      SDLValidationParameters:
-        enable: true
-        continueOnError: false
-        params: ' -SourceToolsList @("policheck","credscan")
-        -TsaInstanceURL $(_TsaInstanceURL)
-        -TsaProjectName $(_TsaProjectName)
-        -TsaNotificationEmail $(_TsaNotificationEmail)
-        -TsaCodebaseAdmin $(_TsaCodebaseAdmin)
-        -TsaBugAreaPath $(_TsaBugAreaPath)
-        -TsaIterationPath $(_TsaIterationPath)
-        -TsaRepositoryName "EntityFramework6"
-        -TsaCodebaseName "EntityFramework6"
-        -TsaPublish $True'

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -1,0 +1,9 @@
+-SourceToolsList @("policheck","credscan")
+-TsaInstanceURL https://devdiv.visualstudio.com/
+-TsaProjectName DEVDIV
+-TsaNotificationEmail aspnetcore-build@microsoft.com
+-TsaCodebaseAdmin REDMOND\kevinpi
+-TsaBugAreaPath DevDiv\Entity Framework
+-TsaIterationPath DevDiv
+-TsaOnboard $True
+-TsaPublish $True

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -5,5 +5,7 @@
 -TsaCodebaseAdmin REDMOND\kevinpi
 -TsaBugAreaPath DevDiv\Entity Framework
 -TsaIterationPath DevDiv
+-TsaRepositoryName EntityFramework6
+-TsaCodebaseName EntityFramework6
 -TsaOnboard $True
 -TsaPublish $True

--- a/eng/sdl-tsa-vars.config
+++ b/eng/sdl-tsa-vars.config
@@ -3,9 +3,9 @@
 -TsaProjectName DEVDIV
 -TsaNotificationEmail aspnetcore-build@microsoft.com
 -TsaCodebaseAdmin REDMOND\kevinpi
--TsaBugAreaPath DevDiv\Entity Framework
+-TsaBugAreaPath "DevDiv\Entity Framework"
 -TsaIterationPath DevDiv
--TsaRepositoryName EntityFramework6
--TsaCodebaseName EntityFramework6
+-TsaRepositoryName ef6
+-TsaCodebaseName ef6
 -TsaOnboard $True
 -TsaPublish $True


### PR DESCRIPTION
Moves SDL out of the repo build and into the ringed release pipeline, as per the goal of reducing build time. CC @Pilchie @ajcvickers 