### PR TITLE
Fix dependency update PR

### DIFF
--- a/src/ef6/ef6.csproj
+++ b/src/ef6/ef6.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs" />
     <Compile Include="..\EntityFramework\Infrastructure\Design\HandlerBase.cs" />
     <Compile Include="..\EntityFramework\Infrastructure\Design\IReportHandler.cs" />
     <Compile Include="..\EntityFramework\Infrastructure\Design\IResultHandler.cs" />


### PR DESCRIPTION
This should work around the issue that's preventing #1678 (an SDK dependency update PR) from building. ~I'm not sure why this wasn't necessary before.~ See why below.