### PR TITLE
Feature Request : Enable MIN/MAX aggrgates on HierarchyId type

### DIFF
--- a/src/EntityFramework/Core/Metadata/Edm/Provider/EdmProviderManifest.cs
+++ b/src/EntityFramework/Core/Metadata/Edm/Provider/EdmProviderManifest.cs
@@ -581,7 +581,8 @@ namespace System.Data.Entity.Core.Metadata.Edm.Provider
                     PrimitiveTypeKind.String,
                     PrimitiveTypeKind.Binary,
                     PrimitiveTypeKind.Time,
-                    PrimitiveTypeKind.DateTimeOffset
+                    PrimitiveTypeKind.DateTimeOffset,
+                    PrimitiveTypeKind.HierarchyId
                 };
 
             EdmProviderManifestFunctionBuilder.ForTypes(parameterTypes, type => functions.AddAggregate("Max", type));


### PR DESCRIPTION
Just adding overlooked HierarchyId mapping of aggregates 

Use-case : allowing for simple expression of root/leaf nodes filtering within LINQ.