### PR TITLE
Publish EF6 designer DLLs and PDBs

### DIFF
--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -239,7 +239,7 @@ steps:
     PathToPublish: '$(Build.ArtifactStagingDirectory)\BuildDLLs'
     ArtifactName: BuildDLLs
     publishLocation: FilePath
-    TargetPath: '$(DropFileShare)\$(Build.SourceBranchName)\$(Build.BuildId)\VS2019'
+    TargetPath: '$(DropFileShare)\190313_Dev16_MicroBuild_07\$(Build.BuildId)\VS2019'
 
 - task: CopyFiles@2
 

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -228,9 +228,7 @@ steps:
   inputs:
     SourceFolder: 'bin\$(BuildConfiguration)'
     Contents: |
-     EntityFramework*.dll
-     EntityFramework*.pdb
-     migrate.exe
+     **
     TargetFolder: '$(Build.ArtifactStagingDirectory)\BinDir'
 
 - task: PublishBuildArtifacts@1

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -226,7 +226,7 @@ steps:
 - task: CopyFiles@2
   displayName: 'Copy EF6 dlls'
   inputs:
-    SourceFolder: 'bin\$(BuildConfiguration)'
+    SourceFolder: 'bin\'
     Contents: |
      **
     TargetFolder: '$(Build.ArtifactStagingDirectory)\BinDir'

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -231,7 +231,7 @@ steps:
      EntityFramework*.dll
      EntityFramework*.pdb
      migrate.exe
-    TargetFolder: '$(Build.ArtifactsStagingDirectory)\BuildDLLs'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\BuildDLLs'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish EF6 dlls'

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -231,13 +231,13 @@ steps:
      EntityFramework*.dll
      EntityFramework*.pdb
      migrate.exe
-    TargetFolder: '$(Build.ArtifactStagingDirectory)\BuildDLLs'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\BinDir'
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish EF6 dlls'
   inputs:
-    PathToPublish: '$(Build.ArtifactStagingDirectory)\BuildDLLs'
-    ArtifactName: BuildDLLs
+    PathToPublish: '$(Build.ArtifactStagingDirectory)\BinDir'
+    ArtifactName: BinDir
     publishLocation: FilePath
     TargetPath: '$(DropFileShare)\190313_Dev16_MicroBuild_07\$(Build.BuildId)\VS2019'
 

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -10,31 +10,31 @@ pool:
 
 
 
-#Your build pipeline references an undefined variable named �comspec�. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+#Your build pipeline references an undefined variable named 'comspec'. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
 
-#Your build pipeline references the �BuildConfiguration� variable, which you�ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the 'BuildConfiguration' variable, which you've selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the �BuildConfiguration� variable, which you�ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the 'BuildConfiguration' variable, which you've selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the �SigningType� variable, which you�ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the 'SigningType' variable, which you've selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the �BuildConfiguration� variable, which you�ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the 'BuildConfiguration' variable, which you've selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references an undefined variable named �comspec�. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+#Your build pipeline references an undefined variable named 'comspec'. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
 
-#Your build pipeline references the �BuildConfiguration� variable, which you�ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the 'BuildConfiguration' variable, which you've selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the �BuildConfiguration� variable, which you�ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the 'BuildConfiguration' variable, which you've selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references an undefined variable named �comspec�. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+#Your build pipeline references an undefined variable named 'comspec'. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
 
-#Your build pipeline references the �BuildConfiguration� variable, which you�ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the 'BuildConfiguration' variable, which you've selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the �BuildConfiguration� variable, which you�ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the 'BuildConfiguration' variable, which you've selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the �BuildConfiguration� variable, which you�ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the 'BuildConfiguration' variable, which you've selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the �BuildConfiguration� variable, which you�ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the 'BuildConfiguration' variable, which you've selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
 variables:
 
@@ -47,7 +47,7 @@ steps:
 - powershell: |
    # Write your powershell commands here.
    
-   $path = & �${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe� -prerelease -all -latest -property installationPath
+   $path = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease -all -latest -property installationPath
    Write-Output $path
    
    # Use the environment variables input below to pass secret variables to this script.

--- a/build/EF6Tools-VS2019-Nightly.yaml
+++ b/build/EF6Tools-VS2019-Nightly.yaml
@@ -10,31 +10,31 @@ pool:
 
 
 
-#Your build pipeline references an undefined variable named ‘comspec’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+#Your build pipeline references an undefined variable named ï¿½comspecï¿½. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
 
-#Your build pipeline references the ‘BuildConfiguration’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ï¿½BuildConfigurationï¿½ variable, which youï¿½ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the ‘BuildConfiguration’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ï¿½BuildConfigurationï¿½ variable, which youï¿½ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the ‘SigningType’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ï¿½SigningTypeï¿½ variable, which youï¿½ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the ‘BuildConfiguration’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ï¿½BuildConfigurationï¿½ variable, which youï¿½ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references an undefined variable named ‘comspec’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+#Your build pipeline references an undefined variable named ï¿½comspecï¿½. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
 
-#Your build pipeline references the ‘BuildConfiguration’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ï¿½BuildConfigurationï¿½ variable, which youï¿½ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the ‘BuildConfiguration’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ï¿½BuildConfigurationï¿½ variable, which youï¿½ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references an undefined variable named ‘comspec’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
+#Your build pipeline references an undefined variable named ï¿½comspecï¿½. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
 
-#Your build pipeline references the ‘BuildConfiguration’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ï¿½BuildConfigurationï¿½ variable, which youï¿½ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the ‘BuildConfiguration’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ï¿½BuildConfigurationï¿½ variable, which youï¿½ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the ‘BuildConfiguration’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ï¿½BuildConfigurationï¿½ variable, which youï¿½ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
-#Your build pipeline references the ‘BuildConfiguration’ variable, which you’ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
+#Your build pipeline references the ï¿½BuildConfigurationï¿½ variable, which youï¿½ve selected to be settable at queue time. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 
 variables:
 
@@ -47,7 +47,7 @@ steps:
 - powershell: |
    # Write your powershell commands here.
    
-   $path = & “${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe” -prerelease -all -latest -property installationPath
+   $path = & ï¿½${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exeï¿½ -prerelease -all -latest -property installationPath
    Write-Output $path
    
    # Use the environment variables input below to pass secret variables to this script.
@@ -223,6 +223,23 @@ steps:
   timeoutInMinutes: 30
 
 
+- task: CopyFiles@2
+  displayName: 'Copy EF6 dlls'
+  inputs:
+    SourceFolder: 'bin\$(BuildConfiguration)'
+    Contents: |
+     EntityFramework*.dll
+     EntityFramework*.pdb
+     migrate.exe
+    TargetFolder: '$(Build.ArtifactsStagingDirectory)\BuildDLLs'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish EF6 dlls'
+  inputs:
+    PathToPublish: '$(Build.ArtifactStagingDirectory)\BuildDLLs'
+    ArtifactName: BuildDLLs
+    publishLocation: FilePath
+    TargetPath: '$(DropFileShare)\$(Build.SourceBranchName)\$(Build.BuildId)\VS2019'
 
 - task: CopyFiles@2
 

--- a/src/EFTools/README.md
+++ b/src/EFTools/README.md
@@ -1,6 +1,7 @@
 ## How to build locally
 1. Make sure you have the WiX Toolset installled. https://wixtoolset.org/releases/ (Note that you need the Toolset, not the VSExtension)
 1. Make sure you have https://www.microsoft.com/en-US/download/details.aspx?id=40760 and https://my.visualstudio.com/Downloads?q=visual%20studio%202012&wt.mc_id=o~msft~vscom~older-downloads with the 2012 SDK installed.
+1. Also install https://my.visualstudio.com/Downloads?q=visual%20studio%202017&wt.mc_id=o~msft~vscom~older-downloads VS2017
 1. Launch the VS2019 Developer command prompt. (It has to be this, due to reasons).
 1. Make sure that NuGet is available on the path.
 1. .\BuildEFTools.cmd from the root of this repo.

--- a/src/EFTools/README.md
+++ b/src/EFTools/README.md
@@ -1,6 +1,6 @@
 ## How to build locally
 1. Make sure you have the WiX Toolset installled. https://wixtoolset.org/releases/ (Note that you need the Toolset, not the VSExtension)
-1. Make sure you have https://www.microsoft.com/en-US/download/details.aspx?id=40760 installed.
+1. Make sure you have https://www.microsoft.com/en-US/download/details.aspx?id=40760 and https://my.visualstudio.com/Downloads?q=visual%20studio%202012&wt.mc_id=o~msft~vscom~older-downloads with the 2012 SDK installed.
 1. Launch the VS2019 Developer command prompt. (It has to be this, due to reasons).
 1. Make sure that NuGet is available on the path.
 1. .\BuildEFTools.cmd from the root of this repo.

--- a/src/EFTools/README.md
+++ b/src/EFTools/README.md
@@ -1,5 +1,6 @@
 ## How to build locally
 1. Make sure you have the WiX Toolset installled. https://wixtoolset.org/releases/ (Note that you need the Toolset, not the VSExtension)
+1. Make sure you have https://www.microsoft.com/en-US/download/details.aspx?id=40760 installed.
 1. Launch the VS2019 Developer command prompt. (It has to be this, due to reasons).
 1. Make sure that NuGet is available on the path.
 1. .\BuildEFTools.cmd from the root of this repo.


### PR DESCRIPTION
Currently we don't Publish all the DLL's and PDB's that this build produces, which we need in order to archive them for the VS symbol-server. This should start preserving those DLL's for use in just such a manner.