### PR TITLE
add async overload for ExecuteFunction on ObjectContext

### DIFF
--- a/src/EntityFramework/Core/Objects/ObjectContext.cs
+++ b/src/EntityFramework/Core/Objects/ObjectContext.cs
@@ -42,8 +42,6 @@ namespace System.Data.Entity.Core.Objects
 #endif
     using System.Transactions;
     using System.Collections.ObjectModel;
-    using System.Threading;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// ObjectContext is the top-level object that encapsulates a connection between the CLR and the database,


### PR DESCRIPTION
I work in a legacy project and while creating a new context, noticed that there were no async overloads for the function calls that were generated in the EF template and that they were unavailable. Since I need these, I thought I'd add them.

This was just copy-pasting existing code with async function calls