### PR TITLE
feat: add validation to prevent invalid migrations name

### DIFF
--- a/src/ef6/Commands/MigrationsAddCommand.cs
+++ b/src/ef6/Commands/MigrationsAddCommand.cs
@@ -35,6 +35,10 @@ namespace System.Data.Entity.Tools.Commands
             {
                 throw new CommandException(string.Format(MyResources.MissingArgument, _name.Name));
             }
+            if (_name.Name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                throw new CommandException("Invalid migration name. Names must not contain any invalid characters, e.g [-,/,:]");
+            }
         }
 
         protected override int Execute()


### PR DESCRIPTION
If we use reserve key character while adding a new migration it doesn't work as aspected for eg `dotnet ef migrations add "add: user`, this tries to create a migration file same as provided name, but we are using the reserve key characters, i don't know how but it's an unknown migrations file.

## Steps to reproduce
 - Adding initial migration
![image](https://user-images.githubusercontent.com/71131016/177293452-4bad7351-eae3-4780-9331-21cd062d27c0.png)
- Error
![image](https://user-images.githubusercontent.com/71131016/177293742-9db6e758-c307-45c3-b7f0-78dd9936c044.png)

So, I've tried to fix this issue, I apologize if this brings the breaking changes. 

