### PR TITLE
[release/6.4] Switch public pool and use consolidated build images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
             timeoutInMinutes: 180
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                name: NetCore-Public
+                name: NetCore-Svc-Public
                 demands: ImageOverride -equals 1es-windows-2019-open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Svc-Internal

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,9 +19,12 @@ variables:
       value: ''
 
 trigger:
-  - master
-  - release/*
-  - internal/release/6.*
+  batch: true
+  branches:
+    include:
+      - main
+      - release/*
+      - internal/release/6.*
 
 pr: ['*']
 
@@ -37,13 +40,13 @@ stages:
         enablePublishTestResults: true
         enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
         enableTelemetry: true
-        helixRepo: aspnet/EntityFramework6
+        helixRepo: dotnet/ef6
         jobs:
           - job: Windows
             timeoutInMinutes: 180
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
-                name: NetCore1ESPool-Svc-Public
+                name: NetCore-Public
                 demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Svc-Internal

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,10 +47,10 @@ stages:
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: NetCore-Public
-                demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
+                demands: ImageOverride -equals 1es-windows-2019-open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Svc-Internal
-                demands: ImageOverride -equals Build.Server.Amd64.VS2019
+                demands: ImageOverride -equals 1es-windows-2019
             variables:
               - _InternalBuildArgs: ''
               - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:


### PR DESCRIPTION
[release/6.4] Update public pool names

  - backport of #2029
- [release/6.4] Switch to consolidated Windows build images
  - backport of #2039