### PR TITLE
Add CodeQL3000 run to ef6-ci-official

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,12 @@
+{
+  "areaPath": "DevDiv\\ASP.NET Core",
+  "codebaseName": "AspNetCore",
+  "instanceUrl": "https://devdiv.visualstudio.com/",
+  "iterationPath": "DevDiv",
+  "notificationAliases": [
+    "aspnetcore-build@microsoft.com"
+  ],
+  "projectName": "DEVDIV",
+  "repositoryName": "AspNetCore",
+  "template": "TFSDEVDIV"
+}

--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,12 +1,12 @@
 {
-  "areaPath": "DevDiv\\ASP.NET Core",
-  "codebaseName": "AspNetCore",
+  "areaPath": "DevDiv\\Entity Framework",
+  "codebaseName": "ef6",
   "instanceUrl": "https://devdiv.visualstudio.com/",
   "iterationPath": "DevDiv",
   "notificationAliases": [
     "aspnetcore-build@microsoft.com"
   ],
   "projectName": "DEVDIV",
-  "repositoryName": "AspNetCore",
+  "repositoryName": "ef6",
   "template": "TFSDEVDIV"
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,24 @@
+schedules:
+- cron: 0 9 * * 1
+  displayName: "Run CodeQL3000 weekly, Monday at 2:00 AM PDT"
+  branches:
+    include:
+    - release/2.1
+    - release/6.0
+    - release/7.0
+    - main
+  always: true
+
+parameters:
+# Parameter below is ignored in public builds.
+#
+# Choose whether to run the CodeQL3000 tasks.
+# Manual builds align w/ official builds unless this parameter is true.
+- name: runCodeQL3000
+  default: false
+  displayName: Run CodeQL3000 tasks
+  type: boolean
+
 variables:
   - name: _BuildConfig
     value: Release
@@ -17,6 +38,8 @@ variables:
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
     - name: _InternalRuntimeDownloadArgs
       value: ''
+  - name: runCodeQL3000
+    value: ${{ and(ne(variables['System.TeamProject'], 'public'), or(eq(variables['Build.Reason'], 'Schedule'), and(eq(variables['Build.Reason'], 'Manual'), eq(parameters.runCodeQL3000, 'true')))) }}
 
 trigger:
   batch: true
@@ -34,16 +57,15 @@ stages:
   jobs:
     - template: eng/common/templates/jobs/jobs.yml
       parameters:
-        enableMicrobuild: true
+        enableMicrobuild: ${{ ne(variables.runCodeQL3000, 'true') }}
         enablePublishBuildArtifacts: true
-        enablePublishBuildAssets: true
-        enablePublishTestResults: true
+        enablePublishBuildAssets: ${{ ne(variables.runCodeQL3000, 'true') }}
+        enablePublishTestResults: ${{ ne(variables.runCodeQL3000, 'true') }}
         enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
         enableTelemetry: true
         helixRepo: dotnet/ef6
         jobs:
           - job: Windows
-            timeoutInMinutes: 180
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: NetCore-Public
@@ -51,21 +73,35 @@ stages:
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: NetCore1ESPool-Internal
                 demands: ImageOverride -equals 1es-windows-2019
+            ${{ if eq(variables.runCodeQL3000, 'true') }}:
+              # Component governance and SBOM creation are not needed here. Disable what Arcade would inject.
+              disableComponentGovernance: true
+              enableSbom: false
+              # CodeQL3000 extends build duration.
+              timeoutInMinutes: 240
+            ${{ else }:
+              timeoutInMinutes: 180
             variables:
               - _InternalBuildArgs: ''
               - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                 - group: DotNet-Blob-Feed
                 - _SignType: real
-                - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/aspnet-entityframework6/index.json
-                - _DotNetPublishToBlobFeed: true
                 - _InternalBuildArgs: /p:DotNetSignType=$(_SignType)
                                       /p:TeamName=$(_TeamName)
-                                      /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                                      /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
-                                      /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
                                       /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
                                       /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                                       /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+              - ${{ if eq(variables.runCodeQL3000, 'true') }}:
+                - Codeql.SourceRoot: src
+                - _AdditionalBuildArgs: /p:Test=false /p:Sign=false /p:Pack=false /p:Publish=false /p:UseSharedCompilation=false
+                # Security analysis is included in normal runs. Disable its auto-injection.
+                - skipNugetSecurityAnalysis: true
+                # Do not let CodeQL3000 Extension gate scan frequency.
+                - Codeql.Cadence: 0
+                # Enable CodeQL3000 unconditionally so it may be run on any branch.
+                - Codeql.Enabled: true
+                # CodeQL3000 needs this plumbed along as a variable to enable TSA.
+                - Codeql.TSAEnabled: ${{ eq(variables['Build.Reason'], 'Schedule') }}
             steps:
               - checkout: self
                 clean: true
@@ -91,27 +127,37 @@ stages:
                     arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
                   env:
                     Token: $(dn-bot-dnceng-artifact-feeds-rw)
-              - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_InternalBuildArgs) $(_InternalRuntimeDownloadArgs)
+              - ${{ if eq(variables.runCodeQL3000, 'true') }}:
+                - script: "echo ##vso[build.addbuildtag]CodeQL3000"
+                  displayName: 'Set CI CodeQL3000 tag'
+                - task: CodeQL3000Init@0
+                  displayName: CodeQL Initialize
+              - script: eng\common\cibuild.cmd -configuration $(_BuildConfig) -prepareMachine $(_InternalBuildArgs)
+                  $(_InternalRuntimeDownloadArgs) $(_AdditionalBuildArgs)
                 name: Build
-              - task: PublishBuildArtifacts@1
-                displayName: Upload TestResults
-                condition: always()
-                continueOnError: true
-                inputs:
-                  pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
-                  artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
-                  artifactType: Container
-                  parallel: true
-              - task: PublishBuildArtifacts@1
-                displayName: Upload artifacts
-                condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
-                inputs:
-                  pathtoPublish: 'artifacts/packages/'
-                  artifactName: packages
-                  artifactType: Container
-                  parallel: true
+              - ${{ if eq(variables.runCodeQL3000, 'true') }}:
+                - task: CodeQL3000Finalize@0
+                  displayName: CodeQL Finalize
+              - ${{ else }}:
+                - task: PublishBuildArtifacts@1
+                  displayName: Upload TestResults
+                  condition: always()
+                  continueOnError: true
+                  inputs:
+                    pathtoPublish: artifacts/TestResults/$(_BuildConfig)/
+                    artifactName: $(Agent.Os)_$(Agent.JobName) TestResults
+                    artifactType: Container
+                    parallel: true
+                - task: PublishBuildArtifacts@1
+                  displayName: Upload artifacts
+                  condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false))
+                  inputs:
+                    pathtoPublish: 'artifacts/packages/'
+                    artifactName: packages
+                    artifactType: Container
+                    parallel: true
 
-- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+- ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest'), ne(variables.runCodeQL3000, 'true')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
       # Symbol validation isn't being very reliable lately. This should be enabled back

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ stages:
               enableSbom: false
               # CodeQL3000 extends build duration.
               timeoutInMinutes: 240
-            ${{ else }:
+            ${{ else }}:
               timeoutInMinutes: 180
             variables:
               - _InternalBuildArgs: ''

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,9 +3,6 @@ schedules:
   displayName: "Run CodeQL3000 weekly, Monday at 2:00 AM PDT"
   branches:
     include:
-    - release/2.1
-    - release/6.0
-    - release/7.0
     - main
   always: true
 


### PR DESCRIPTION
- add new schedule for a weekly run
- add top-level parameter enabling CodeQL3000 in manual builds
- mix CodeQL3000 tasks into regular build; avoid large duplications
  - set `$(UseSharedCompilation)` to `false` to ease analysis
- tag CodeQL3000 runs
- add a tsaoptions.json file
  - cribbed values from our eng/sdl-tsa-vars.config file

nits:
- unconditionally disable the auto-injected component governance build step
  - job.yml inserts the task where we need (unless overridden)
- remove use of deprecated `$(DotNetPublish...)` properties