### PR TITLE
Define variable

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,6 +80,7 @@ stages:
             ${{ else }}:
               timeoutInMinutes: 180
             variables:
+              - _AdditionalBuildArgs: ''
               - _InternalBuildArgs: ''
               - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
                 - group: DotNet-Blob-Feed


### PR DESCRIPTION
```
_AdditionalBuildArgs : The term '_AdditionalBuildArgs' is not recognized as the name of a cmdlet, function, script  file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct  and try again.
At line:1 char:131
+ ...  -ci -configuration Release -prepareMachine   $(_AdditionalBuildArgs)
+                                                     ~~~~~~~~~~~~~~~~~~~~
```