### PR TITLE
Propose switching test projects to minimum net462

### DIFF
--- a/test/FunctionalTests.ProviderAgnostic/Configuration/MySqlConnectionFactory.cs
+++ b/test/FunctionalTests.ProviderAgnostic/Configuration/MySqlConnectionFactory.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 namespace System.Data.Entity.Configuration
 {
     using MySql.Data.MySqlClient;

--- a/test/FunctionalTests.ProviderAgnostic/Configuration/MySqlHistoryContext.cs
+++ b/test/FunctionalTests.ProviderAgnostic/Configuration/MySqlHistoryContext.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 namespace System.Data.Entity.Configuration
 {
     using System.Data.Common;

--- a/test/FunctionalTests.ProviderAgnostic/Configuration/ProviderAgnosticConfiguration.cs
+++ b/test/FunctionalTests.ProviderAgnostic/Configuration/ProviderAgnosticConfiguration.cs
@@ -7,7 +7,7 @@ namespace System.Data.Entity.Configuration
     using System.Data.Entity.Infrastructure;
     using System.Data.Entity.SqlServer;
 
-#if NET452
+#if NETFRAMEWORK
     using System.Runtime.Remoting.Messaging;
     using MySql.Data.MySqlClient;
 #else
@@ -16,7 +16,7 @@ namespace System.Data.Entity.Configuration
 
     public class ProviderAgnosticConfiguration : DbConfiguration
     {
-#if NET452
+#if NETFRAMEWORK
         private static readonly string _providerInvariantName = ConfigurationManager.AppSettings["ProviderInvariantName"];
         private static readonly string _baseConnectionString = ConfigurationManager.AppSettings["BaseConnectionString"];
 #else
@@ -27,7 +27,7 @@ namespace System.Data.Entity.Configuration
 
         public ProviderAgnosticConfiguration()
         {
-#if NET452
+#if NETFRAMEWORK
             SetHistoryContext(
                 "MySql.Data.MySqlClient",
                 (connection, defaultSchema) => new MySqlHistoryContext(connection, defaultSchema));
@@ -43,7 +43,7 @@ namespace System.Data.Entity.Configuration
                     SetDefaultConnectionFactory(new SqlConnectionFactory(_baseConnectionString));
                     break;
 
-#if NET452
+#if NETFRAMEWORK
                 case "MySql.Data.MySqlClient" :
                     SetDefaultConnectionFactory(new MySqlConnectionFactory());
                     break;
@@ -58,7 +58,7 @@ namespace System.Data.Entity.Configuration
 
         public static bool SuspendExecutionStrategy
         {
-#if NET452
+#if NETFRAMEWORK
             get => (bool?)CallContext.LogicalGetData("SuspendExecutionStrategy") ?? false;
             set => CallContext.LogicalSetData("SuspendExecutionStrategy", value);
 #else

--- a/test/FunctionalTests.ProviderAgnostic/FunctionalTests.ProviderAgnostic.csproj
+++ b/test/FunctionalTests.ProviderAgnostic/FunctionalTests.ProviderAgnostic.csproj
@@ -3,16 +3,16 @@
   <PropertyGroup>
     <RootNamespace>System.Data.Entity</RootNamespace>
     <AssemblyName>EntityFramework.FunctionalTests.ProviderAgnostic</AssemblyName>
-    <TargetFrameworks>net452;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>net462;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <DefineConstants>$(DefineConstants);EF_FUNCTIONALS</DefineConstants>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="MySql.Data.Entity" Version="$(MySqlDataEntityVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Transactions" />

--- a/test/FunctionalTests.ProviderAgnostic/ProductivityApi/GetHashCodeTests.cs
+++ b/test/FunctionalTests.ProviderAgnostic/ProductivityApi/GetHashCodeTests.cs
@@ -256,7 +256,7 @@ namespace System.Data.Entity.ProductivityApi
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Serializing_an_entity_that_overrides_GetHashCode_shouldnt_shouldnt_throw()
         {

--- a/test/FunctionalTests.Transitional/CodeFirst/AdvancedMappingScenarioTests.cs
+++ b/test/FunctionalTests.Transitional/CodeFirst/AdvancedMappingScenarioTests.cs
@@ -120,7 +120,7 @@ namespace FunctionalTests
             public virtual string RoleId2 { get; set; }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Sql_ce_should_get_explicit_max_lengths_for_string_and_binary_properties_by_convention()
         {

--- a/test/FunctionalTests.Transitional/CodeFirst/BasicMappingScenarioTests.cs
+++ b/test/FunctionalTests.Transitional/CodeFirst/BasicMappingScenarioTests.cs
@@ -17,7 +17,7 @@ namespace FunctionalTests
     using FunctionalTests.Model;
     using Xunit;
 
-#if NET452
+#if NETFRAMEWORK
     using System.Windows.Media;
 #endif
 
@@ -336,7 +336,7 @@ namespace FunctionalTests
             Assert.Equal("Foo1", databaseMapping.Model.Containers.Single().EntitySets.Last().Name);
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Build_model_for_type_with_framework_type()
         {

--- a/test/FunctionalTests.Transitional/CodeFirst/DataServicesTests.cs
+++ b/test/FunctionalTests.Transitional/CodeFirst/DataServicesTests.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace FunctionalTests
 {

--- a/test/FunctionalTests.Transitional/Design/BasicDesignTimeScenarios.cs
+++ b/test/FunctionalTests.Transitional/Design/BasicDesignTimeScenarios.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Design
 {

--- a/test/FunctionalTests.Transitional/FunctionalTests.Transitional.csproj
+++ b/test/FunctionalTests.Transitional/FunctionalTests.Transitional.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <RootNamespace>System.Data.Entity</RootNamespace>
     <AssemblyName>EntityFramework.FunctionalTests.Transitional</AssemblyName>
-    <TargetFrameworks>net452;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>net462;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="PresentationCore" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -20,7 +20,7 @@
     <PackageReference Include="Moq" Version="$(MoqVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Microsoft.SqlServer.Compact" Version="$(MicrosoftSqlServerCompactVersion)" />
     <PackageReference Include="Microsoft.SqlServer.Types" Version="$(MicrosoftSqlServerTypesVersion)" />
   </ItemGroup>
@@ -29,17 +29,17 @@
     <ProjectReference Include="..\..\src\EntityFramework.SqlServer\EntityFramework.SqlServer.InternalsVisibleTo.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <ProjectReference Include="..\..\src\EntityFramework.SqlServerCompact\EntityFramework.SqlServerCompact.InternalsVisibleTo.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Compile Include="$(NuGetPackageRoot)microsoft.sqlserver.types\$(MicrosoftSqlServerTypesVersion)\content\SqlServerTypes\Loader.cs">
       <Link>SqlServerTypes\Loader.cs</Link>
     </Compile>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Content Include="$(NuGetPackageRoot)microsoft.sqlserver.types\$(MicrosoftSqlServerTypesVersion)\content\readme.htm">
       <Link>SqlServerTypes\readme.htm</Link>
     </Content>
@@ -80,7 +80,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <PostBuildEvent Condition="'$(OS)' == 'Windows_NT' And '$(TargetFramework)' == 'net452'">
+    <PostBuildEvent Condition="'$(OS)' == 'Windows_NT' And '$(TargetFramework)' == 'net462'">
       if not exist "$(TargetDir)x86" md "$(TargetDir)x86"
       xcopy /s /y "$(NuGetPackageRoot)Microsoft.SqlServer.Compact\$(MicrosoftSqlServerCompactVersion)\NativeBinaries\x86\*.*" "$(TargetDir)x86"
       if not exist "$(TargetDir)amd64" md "$(TargetDir)amd64"

--- a/test/FunctionalTests.Transitional/ProductivityApi/DbContextTests.cs
+++ b/test/FunctionalTests.Transitional/ProductivityApi/DbContextTests.cs
@@ -39,7 +39,7 @@ namespace ProductivityApiTests
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Can_replace_connection_with_different_provider()
         {

--- a/test/FunctionalTests.Transitional/TestHelpers/DbContextExtensions.cs
+++ b/test/FunctionalTests.Transitional/TestHelpers/DbContextExtensions.cs
@@ -4,7 +4,7 @@ namespace System.Data.Entity
 {
     using System.Data.Entity.Migrations;
 
-#if NET452
+#if NETFRAMEWORK
     using System.Data.SqlServerCe;
 #endif
 
@@ -27,7 +27,7 @@ namespace System.Data.Entity
 
         public static bool IsSqlCe(this DbContext context)
         {
-#if NET452
+#if NETFRAMEWORK
             return context.Database.Connection is SqlCeConnection;
 #else
             return false;

--- a/test/FunctionalTests.Transitional/TestHelpers/ExceptionHelpers.cs
+++ b/test/FunctionalTests.Transitional/TestHelpers/ExceptionHelpers.cs
@@ -188,7 +188,7 @@ namespace System.Data.Entity
             return null;
         }
 
-#if NET452
+#if NETFRAMEWORK
         /// <summary>
         /// Serializes and de-serializes the given exception and returns the de-serialized instance.
         /// </summary>

--- a/test/FunctionalTests.Transitional/TestHelpers/FunctionalTestsConfiguration.cs
+++ b/test/FunctionalTests.Transitional/TestHelpers/FunctionalTestsConfiguration.cs
@@ -7,7 +7,7 @@ namespace System.Data.Entity.TestHelpers
     using System.Data.Entity.Infrastructure.DependencyResolution;
     using System.Data.Entity.SqlServer;
     using System.Linq;
-#if NET452
+#if NETFRAMEWORK
     using System.Data.Entity.SqlServerCompact;
 #endif
 
@@ -62,7 +62,7 @@ namespace System.Data.Entity.TestHelpers
 
         public FunctionalTestsConfiguration()
         {
-#if NET452
+#if NETFRAMEWORK
             SetProviderServices(SqlCeProviderServices.ProviderInvariantName, SqlCeProviderServices.Instance);
 #endif
             SetProviderServices(SqlProviderServices.ProviderInvariantName, SqlProviderServices.Instance);

--- a/test/FunctionalTests.Transitional/TestHelpers/IOHelpers.cs
+++ b/test/FunctionalTests.Transitional/TestHelpers/IOHelpers.cs
@@ -23,7 +23,7 @@ namespace System.Data.Entity
         /// </summary>
         /// <param name="path"> The path to test. </param>
         /// <returns> True if path refers to an existing directory; otherwise, false. </returns>
-#if NET452
+#if NETFRAMEWORK
         [SecuritySafeCritical]
         // Calling Directory.Exists demands FileIOPermission (Read flag) for the specified path.
         [PermissionSet(SecurityAction.Assert, Unrestricted = true)]
@@ -37,7 +37,7 @@ namespace System.Data.Entity
         /// Creates the specified directory if it doesn't exist or removes all contents of an existing directory.
         /// </summary>
         /// <param name="path"> Path to directory to create. </param>
-#if NET452
+#if NETFRAMEWORK
         [SecuritySafeCritical]
         // Calling Directory.Exists demands FileIOPermission (Read flag) for the specified path.
         [PermissionSet(SecurityAction.Assert, Unrestricted = true)]
@@ -56,7 +56,7 @@ namespace System.Data.Entity
         /// Creates the specified directory if it doesn't exist.
         /// </summary>
         /// <param name="path"> Path to directory to create. </param>
-#if NET452
+#if NETFRAMEWORK
         [SecuritySafeCritical]
         // Calling Directory.Exists and Directory.CreateDirectory demands FileIOPermission (Read | Write) for the specified path.
         [PermissionSet(SecurityAction.Assert, Unrestricted = true)]
@@ -74,7 +74,7 @@ namespace System.Data.Entity
         /// </summary>
         /// <param name="path"> The file to check. </param>
         /// <returns> True if the caller has the required permissions and path contains the name of an existing file; otherwise, false. This method also returns false if path is null, an invalid path, or a zero-length string. If the caller does not have sufficient permissions to read the specified file, no exception is thrown and the method returns false regardless of the existence of path. </returns>
-#if NET452
+#if NETFRAMEWORK
         [SecuritySafeCritical]
         // Calling File.Exists demands FileIOPermission (Read flag) for the specified path.
         [PermissionSet(SecurityAction.Assert, Unrestricted = true)]
@@ -89,7 +89,7 @@ namespace System.Data.Entity
         /// </summary>
         /// <param name="path"> The file or directory for which to obtain absolute path information. </param>
         /// <returns> A string containing the fully qualified location of path, such as "C:\MyFile.txt". </returns>
-#if NET452
+#if NETFRAMEWORK
         [SecuritySafeCritical]
         // Calling Path.GetFullPath demands FileIOPermission (PathDiscovery flag) for the specified path.
         [PermissionSet(SecurityAction.Assert, Unrestricted = true)]
@@ -103,7 +103,7 @@ namespace System.Data.Entity
         /// Safely deletes the file and ignores any access violation exceptions.
         /// </summary>
         /// <param name="path"> The directory to delete. </param>
-#if NET452
+#if NETFRAMEWORK
         [SecuritySafeCritical]
         // Calling File.Delete demands FileIOPermission (Write flag) for the specified path.
         [PermissionSet(SecurityAction.Assert, Unrestricted = true)]
@@ -125,7 +125,7 @@ namespace System.Data.Entity
         /// Safely deletes the directory and ignores any access violation exceptions.
         /// </summary>
         /// <param name="path"> The directory to delete. </param>
-#if NET452
+#if NETFRAMEWORK
         [SecuritySafeCritical]
         // Calling Directory.Delete demands FileIOPermission (Write flag) for the specified path.
         [PermissionSet(SecurityAction.Assert, Unrestricted = true)]
@@ -184,7 +184,7 @@ namespace System.Data.Entity
         /// </summary>
         /// <param name="destinationDirectory"> The destination directory. </param>
         /// <param name="sourceFiles"> The source files. </param>
-#if NET452
+#if NETFRAMEWORK
         [SecuritySafeCritical]
         // Calling File.Copy demands FileIOPermission (Write flag) for the destination file path.
         [PermissionSet(SecurityAction.Assert, Unrestricted = true)]
@@ -258,7 +258,7 @@ namespace System.Data.Entity
         /// <param name="resourceName"> Resource to be written </param>
         /// <param name="fileName"> File to write resource to </param>
         /// <param name="assembly"> Assembly to extract resource from </param>
-#if !SILVERLIGHT && NET452
+#if !SILVERLIGHT && NETFRAMEWORK
         [SecuritySafeCritical]
         // Calling File.Open demands FileIOPermission (Append flag) for the destination file path.
         [PermissionSet(SecurityAction.Assert, Unrestricted = true)]

--- a/test/FunctionalTests.Transitional/TestHelpers/ResourceUtilities.cs
+++ b/test/FunctionalTests.Transitional/TestHelpers/ResourceUtilities.cs
@@ -32,7 +32,7 @@ namespace System.Data.Entity
         /// so you should put all your resources under 'Resources' directory within a project)
         /// and appends '.gz' to it. You should use gzip to produce compressed files.
         /// </remarks>
-#if NET452
+#if NETFRAMEWORK
         [SecuritySafeCritical]
         // Calling File.Create demands FileIOPermission (Write flag) for the file path to which the resource is extracted.
         [PermissionSet(SecurityAction.Assert, Unrestricted = true)]

--- a/test/FunctionalTests.Transitional/TestHelpers/TestBase.cs
+++ b/test/FunctionalTests.Transitional/TestHelpers/TestBase.cs
@@ -26,7 +26,7 @@ namespace System.Data.Entity
     {
         static TestBase()
         {
-#if NET452
+#if NETFRAMEWORK
             SqlServerTypes.Utilities.LoadNativeAssemblies(
                 Path.GetDirectoryName(typeof(FunctionalTestBase).Assembly.Location));
 #endif
@@ -160,7 +160,7 @@ namespace System.Data.Entity
         }
 
         public const string SystemComponentModelDataAnnotationsResourceTable
-#if NET452
+#if NETFRAMEWORK
             = "System.ComponentModel.DataAnnotations.Resources.DataAnnotationsResources";
 #else
             = "FxResources.System.ComponentModel.Annotations.SR";
@@ -581,7 +581,7 @@ namespace System.Data.Entity
 
         #endregion
 
-#if NET452
+#if NETFRAMEWORK
         public static void RunTestInAppDomain(Type testType)
         {
             var domain = AppDomain.CreateDomain("TestAppDomain", null, AppDomain.CurrentDomain.SetupInformation);

--- a/test/FunctionalTests/CodeFirst/ModificationFunctionsEndToEndTests.cs
+++ b/test/FunctionalTests/CodeFirst/ModificationFunctionsEndToEndTests.cs
@@ -48,7 +48,7 @@ namespace System.Data.Entity.CodeFirst
                         using (var context = new GearsOfWarStoredProceduresContext())
                         {
                             var city = context.Cities.OrderBy(c => c.Name).First();
-#if NET452
+#if NETFRAMEWORK
                             city.Location = DbGeography.FromText("POINT(12 23)", DbGeography.DefaultCoordinateSystemId);
 #endif
                             context.SaveChanges();
@@ -78,7 +78,7 @@ namespace System.Data.Entity.CodeFirst
                             var squad = context.Squads.OrderBy(s => s.Id).First();
                             var weapon = context.Weapons.OrderBy(w => w.Id).First();
 
-#if NET452
+#if NETFRAMEWORK
                             Assert.Equal(12, city.Location.Longitude);
                             Assert.Equal(23, city.Location.Latitude);
 #endif
@@ -194,7 +194,7 @@ namespace System.Data.Entity.CodeFirst
 
                             city.Name = "Changed City";
                             creature.Details.Attributes.Mana = 123;
-#if NET452
+#if NETFRAMEWORK
                             province.Shape = DbGeometry.FromText("POINT(23 45)", DbGeometry.DefaultCoordinateSystemId);
 #endif
                             npc.Name = "Changed NPC Name";
@@ -213,7 +213,7 @@ namespace System.Data.Entity.CodeFirst
 
                             Assert.Equal("Changed City", city.Name);
                             Assert.Equal(123, creature.Details.Attributes.Mana);
-#if NET452
+#if NETFRAMEWORK
                             Assert.Equal(23, province.Shape.XCoordinate);
                             Assert.Equal(45, province.Shape.YCoordinate);
 #endif

--- a/test/FunctionalTests/FunctionalTests.csproj
+++ b/test/FunctionalTests/FunctionalTests.csproj
@@ -3,12 +3,12 @@
   <PropertyGroup>
     <RootNamespace>System.Data.Entity</RootNamespace>
     <AssemblyName>EntityFramework.FunctionalTests</AssemblyName>
-    <TargetFrameworks>net452;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>net462;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
     <DefineConstants>$(DefineConstants);EF_FUNCTIONALS</DefineConstants>
     <NoWarn>$(NoWarn);CS0169</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
@@ -16,7 +16,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <ProjectReference Include="..\..\src\EntityFramework.SqlServerCompact\EntityFramework.SqlServerCompact.InternalsVisibleTo.csproj" />
   </ItemGroup>
 
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\..\src\EntityFramework.SqlServer\EntityFramework.SqlServer.InternalsVisibleTo.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Content Include="$(NuGetPackageRoot)microsoft.sqlserver.types\$(MicrosoftSqlServerTypesVersion)\content\readme.htm">
       <Link>SqlServerTypes\readme.htm</Link>
     </Content>
@@ -344,7 +344,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <PostBuildEvent Condition="'$(OS)' == 'Windows_NT' And '$(TargetFramework)' == 'net452'">
+    <PostBuildEvent Condition="'$(OS)' == 'Windows_NT' And '$(TargetFramework)' == 'net462'">
       if not exist "$(TargetDir)x86" md "$(TargetDir)x86"
       xcopy /s /y "$(NuGetPackageRoot)Microsoft.SqlServer.Compact\$(MicrosoftSqlServerCompactVersion)\NativeBinaries\x86\*.*" "$(TargetDir)x86"
       if not exist "$(TargetDir)amd64" md "$(TargetDir)amd64"

--- a/test/FunctionalTests/Interception/CommitFailureTests.cs
+++ b/test/FunctionalTests/Interception/CommitFailureTests.cs
@@ -920,7 +920,7 @@ namespace System.Data.Entity.Interception
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void TransactionHandler_is_disposed_even_if_the_context_is_not()
         {

--- a/test/FunctionalTests/Interception/DatabaseLogFormatterTests.cs
+++ b/test/FunctionalTests/Interception/DatabaseLogFormatterTests.cs
@@ -108,7 +108,7 @@ namespace System.Data.Entity.Interception
             _resourceVerifier.VerifyMatch("CommandLogFailed", logLines[3], new AnyValueParameter(), exception.Message, "");
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void DatabaseLogFormatter_is_disposed_even_if_the_context_is_not()
         {

--- a/test/FunctionalTests/Metadata/MetadataAnnotationTests.cs
+++ b/test/FunctionalTests/Metadata/MetadataAnnotationTests.cs
@@ -387,7 +387,7 @@ namespace System.Data.Entity.Metadata
             </Schema>";
 
 
-#if NET452
+#if NETFRAMEWORK
         [Fact] // CodePlex 2051
         public void Can_load_model_after_assembly_version_of_types_changes()
         {

--- a/test/FunctionalTests/Migrations/AddColumnScenarios.cs
+++ b/test/FunctionalTests/Migrations/AddColumnScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/AddForeignKeyScenarios.cs
+++ b/test/FunctionalTests/Migrations/AddForeignKeyScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/AddPrimaryKeyScenarios.cs
+++ b/test/FunctionalTests/Migrations/AddPrimaryKeyScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/AlterColumnScenarios.cs
+++ b/test/FunctionalTests/Migrations/AlterColumnScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/AlterTableAnnotationsScenarios.cs
+++ b/test/FunctionalTests/Migrations/AlterTableAnnotationsScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/AutoAndGenerateScenarios.cs
+++ b/test/FunctionalTests/Migrations/AutoAndGenerateScenarios.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/AutoAndGenerateTestCase.cs
+++ b/test/FunctionalTests/Migrations/AutoAndGenerateTestCase.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/BasicMigrationScenarios.cs
+++ b/test/FunctionalTests/Migrations/BasicMigrationScenarios.cs
@@ -10,7 +10,7 @@ namespace System.Data.Entity.Migrations
     using Xunit;
 
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]
@@ -39,7 +39,7 @@ namespace System.Data.Entity.Migrations
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Database_not_deleted_when_at_least_one_good_migration()
         {
@@ -85,7 +85,7 @@ namespace System.Data.Entity.Migrations
             Assert.True(generatedMigration.MigrationId.Contains("Migration"));
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Generate_should_emit_null_source_when_last_migration_was_explicit()
         {
@@ -127,7 +127,7 @@ namespace System.Data.Entity.Migrations
                                   .Contains("Resources.GetString(\"Source\")"));
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Update_should_execute_pending_custom_scripts()
         {
@@ -161,7 +161,7 @@ namespace System.Data.Entity.Migrations
             Assert.True(generatedMigration.UserCode.Length > 300);
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Update_down_when_target_migration_id_valid_should_migrate_to_target_version_without_timestamp_part()
         {
@@ -330,7 +330,7 @@ namespace System.Data.Entity.Migrations
             Assert.Equal(4, Regex.Matches(generatedMigration.UserCode, "CreateTable").Count);
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Can_generate_and_update_against_empty_source_model()
         {
@@ -375,7 +375,7 @@ namespace System.Data.Entity.Migrations
             WhenNotSqlCe(() => Assert.True(generatedMigration.UserCode.Contains("RenameColumn")));
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Can_update_generate_update_when_empty_target_database()
         {
@@ -440,7 +440,7 @@ namespace System.Data.Entity.Migrations
             Assert.False(TableExists("MigrationsBlogs"));
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Can_update_multiple_migrations_having_a_trailing_automatic_migration()
         {
@@ -526,7 +526,7 @@ namespace System.Data.Entity.Migrations
             Assert.Null(scaffoldedMigration);
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void ScaffoldInitialCreate_should_return_scaffolded_migration_when_db_initialized()
         {
@@ -666,7 +666,7 @@ namespace System.Data.Entity.Migrations
             AssertHistoryContextDoesNotExist();
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Update_down_when_explicit_should_migrate_to_target_version()
         {

--- a/test/FunctionalTests/Migrations/CreateIndexScenarios.cs
+++ b/test/FunctionalTests/Migrations/CreateIndexScenarios.cs
@@ -5,7 +5,7 @@ namespace System.Data.Entity.Migrations
     using System.Data.Entity.Migrations.Model;
 
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]
@@ -24,7 +24,7 @@ namespace System.Data.Entity.Migrations
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Can_create_simple_index()
         {
@@ -86,7 +86,7 @@ namespace System.Data.Entity.Migrations
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Can_create_clustered_index()
         {

--- a/test/FunctionalTests/Migrations/CreateStoredProcedureScenarios.cs
+++ b/test/FunctionalTests/Migrations/CreateStoredProcedureScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/CreateTableScenarios.cs
+++ b/test/FunctionalTests/Migrations/CreateTableScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/CrossDatabaseScenarios.cs
+++ b/test/FunctionalTests/Migrations/CrossDatabaseScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/CustomHistoryScenarios.cs
+++ b/test/FunctionalTests/Migrations/CustomHistoryScenarios.cs
@@ -11,17 +11,17 @@ namespace System.Data.Entity.Migrations
     using System.Linq;
     using Xunit;
 
-#if NET452
+#if NETFRAMEWORK
     using System.Data.SqlServerCe;
 #endif
 
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     public class CustomHistoryScenarios : DbTestCase
     {
-#if NET452
+#if NETFRAMEWORK
         private class NonStandardColumnWidthsContext : HistoryContext
         {
             public NonStandardColumnWidthsContext(DbConnection existingConnection, string defaultSchema)
@@ -121,7 +121,7 @@ namespace System.Data.Entity.Migrations
         {
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Can_auto_update_after_explicit_update_when_custom_history_factory()
         {
@@ -256,7 +256,7 @@ namespace System.Data.Entity.Migrations
             Assert.Throws<EntityCommandExecutionException>(() => migrator.Update());
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Explicit_update_when_factory_changed_move_should_fail()
         {
@@ -369,7 +369,7 @@ namespace System.Data.Entity.Migrations
             Assert.Empty(migrator.GetPendingMigrations());
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Can_use_per_provider_factory()
         {

--- a/test/FunctionalTests/Migrations/CustomSqlScenarios.cs
+++ b/test/FunctionalTests/Migrations/CustomSqlScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/DatabaseGeneratedScenarios.cs
+++ b/test/FunctionalTests/Migrations/DatabaseGeneratedScenarios.cs
@@ -3,7 +3,7 @@
 namespace System.Data.Entity.Migrations
 {
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]

--- a/test/FunctionalTests/Migrations/DefaultValueScenarios.cs
+++ b/test/FunctionalTests/Migrations/DefaultValueScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/DropColumnScenarios.cs
+++ b/test/FunctionalTests/Migrations/DropColumnScenarios.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {
     using Xunit;
 
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]

--- a/test/FunctionalTests/Migrations/DropForeignKeyScenarios.cs
+++ b/test/FunctionalTests/Migrations/DropForeignKeyScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/DropIndexScenarios.cs
+++ b/test/FunctionalTests/Migrations/DropIndexScenarios.cs
@@ -3,7 +3,7 @@
 namespace System.Data.Entity.Migrations
 {
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]

--- a/test/FunctionalTests/Migrations/LoggingScenarios.cs
+++ b/test/FunctionalTests/Migrations/LoggingScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/MappingScenarios.cs
+++ b/test/FunctionalTests/Migrations/MappingScenarios.cs
@@ -3,7 +3,7 @@
 namespace System.Data.Entity.Migrations
 {
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]

--- a/test/FunctionalTests/Migrations/ModificationFunctionsScenarios.cs
+++ b/test/FunctionalTests/Migrations/ModificationFunctionsScenarios.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/MultiTenantScenarios.cs
+++ b/test/FunctionalTests/Migrations/MultiTenantScenarios.cs
@@ -8,7 +8,7 @@ namespace System.Data.Entity.Migrations
     using Xunit;
 
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]
@@ -73,7 +73,7 @@ namespace System.Data.Entity.Migrations
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Can_update_when_explicit_migrations()
         {
@@ -164,7 +164,7 @@ namespace System.Data.Entity.Migrations
             Assert.True(TableExists("TenantBs"));
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
         [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]

--- a/test/FunctionalTests/Migrations/SchemaScenarios.cs
+++ b/test/FunctionalTests/Migrations/SchemaScenarios.cs
@@ -8,7 +8,7 @@ namespace System.Data.Entity.Migrations
     using Xunit;
 
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]
@@ -49,7 +49,7 @@ namespace System.Data.Entity.Migrations
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Can_generate_and_update_when_custom_default_schemas()
         {

--- a/test/FunctionalTests/Migrations/ScriptingScenarios.cs
+++ b/test/FunctionalTests/Migrations/ScriptingScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/SeedingScenarios.cs
+++ b/test/FunctionalTests/Migrations/SeedingScenarios.cs
@@ -6,7 +6,7 @@ namespace System.Data.Entity.Migrations
     using Xunit;
 
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]

--- a/test/FunctionalTests/Migrations/SpatialScenarios.cs
+++ b/test/FunctionalTests/Migrations/SpatialScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/TestHelpers/DatabaseProviderFixture.cs
+++ b/test/FunctionalTests/Migrations/TestHelpers/DatabaseProviderFixture.cs
@@ -55,7 +55,7 @@ namespace System.Data.Entity.Migrations
                 case DatabaseProvider.SqlClient:
                     testDatabase = new SqlTestDatabase(databaseName);
                     break;
-#if NET452
+#if NETFRAMEWORK
                 case DatabaseProvider.SqlServerCe:
                     testDatabase = new SqlCeTestDatabase(databaseName);
                     break;

--- a/test/FunctionalTests/Migrations/TestHelpers/DbTestCase.cs
+++ b/test/FunctionalTests/Migrations/TestHelpers/DbTestCase.cs
@@ -28,7 +28,7 @@ namespace System.Data.Entity.Migrations
     public enum DatabaseProvider
     {
         SqlClient,
-#if NET452
+#if NETFRAMEWORK
         SqlServerCe
 #endif
     }
@@ -98,7 +98,7 @@ namespace System.Data.Entity.Migrations
 
         public bool IsSqlCe
         {
-#if NET452
+#if NETFRAMEWORK
             get { return _databaseProvider == DatabaseProvider.SqlServerCe; }
 #else
             get => false;

--- a/test/FunctionalTests/Migrations/TestHelpers/TestDatabase.cs
+++ b/test/FunctionalTests/Migrations/TestHelpers/TestDatabase.cs
@@ -10,7 +10,7 @@ namespace System.Data.Entity.Migrations
     using System.Data.SqlClient;
     using System.IO;
 
-#if NET452
+#if NETFRAMEWORK
     using System.Data.Entity.SqlServerCompact;
     using System.Data.SqlServerCe;
 #endif
@@ -195,7 +195,7 @@ namespace System.Data.Entity.Migrations
         }
     }
 
-#if NET452
+#if NETFRAMEWORK
     public class SqlCeTestDatabase : TestDatabase
     {
         private readonly string _name;

--- a/test/FunctionalTests/Migrations/TransactionScenarios.cs
+++ b/test/FunctionalTests/Migrations/TransactionScenarios.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Migrations
 {

--- a/test/FunctionalTests/Migrations/UpgradeScenarios.cs
+++ b/test/FunctionalTests/Migrations/UpgradeScenarios.cs
@@ -18,7 +18,7 @@ namespace System.Data.Entity.Migrations
     using Xunit;
 
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.CSharp)]
-#if NET452
+#if NETFRAMEWORK
     [Variant(DatabaseProvider.SqlServerCe, ProgrammingLanguage.CSharp)]
 #endif
     [Variant(DatabaseProvider.SqlClient, ProgrammingLanguage.VB)]
@@ -263,7 +263,7 @@ namespace System.Data.Entity.Migrations
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Scripting_upgrade_from_earlier_version_should_maintain_variable_uniqueness()
         {
@@ -440,7 +440,7 @@ namespace System.Data.Entity.Migrations
             Assert.False(TableExists("dbo." + HistoryContext.DefaultTableName));
         }
 
-#if NET452
+#if NETFRAMEWORK
         [MigrationsTheory]
         public void Can_upgrade_from_5_and_existing_code_auto_migrations_still_work()
         {

--- a/test/FunctionalTests/Objects/AttributeBasedOCLoading.cs
+++ b/test/FunctionalTests/Objects/AttributeBasedOCLoading.cs
@@ -17,7 +17,7 @@ namespace System.Data.Entity.Objects
 
     public class AttributeBasedOCLoading : FunctionalTestBase
     {
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void O_space_types_are_discovered_when_using_attribute_based_mapping()
         {

--- a/test/FunctionalTests/Objects/SerializationScenarios.cs
+++ b/test/FunctionalTests/Objects/SerializationScenarios.cs
@@ -88,7 +88,7 @@ namespace System.Data.Entity.Objects
             public string Word { get; set; }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Change_tracking_proxy_can_be_binary_deserialized_when_running_under_full_trust()
         {
@@ -194,7 +194,7 @@ namespace System.Data.Entity.Objects
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Simple_entities_can_be_binary_serialized_when_running_under_full_trust()
         {
@@ -251,7 +251,7 @@ namespace System.Data.Entity.Objects
                 proxy.Id = 77;
                 proxy.Name = "Entity";
                 proxy.MeComplexTypeS.Number = 88;
-#if NET452
+#if NETFRAMEWORK
                 proxy.Geometry = DbGeometry.FromText("POINT (30 10)");
 #endif
                 proxy.Enum = MeSimpleEntitiesS.EnumType.ZERO;
@@ -265,14 +265,14 @@ namespace System.Data.Entity.Objects
                 Assert.Equal(77, deserialized.Id);
                 Assert.Equal("Entity", deserialized.Name);
                 Assert.Equal(88, deserialized.MeComplexTypeS.Number);
-#if NET452
+#if NETFRAMEWORK
                 Assert.Equal(DbGeometry.FromText("POINT (30 10)").AsText(), deserialized.Geometry.AsText());
 #endif
                 Assert.Equal(MeSimpleEntitiesS.EnumType.ZERO, deserialized.Enum);
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Stored_change_tracking_proxy_can_be_binary_deserialized_when_running_under_full_trust()
         {
@@ -377,7 +377,7 @@ namespace System.Data.Entity.Objects
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Graph_serialization_preserves_related_entities_deserialized_with_binary_deserializer()
         {
@@ -602,7 +602,7 @@ namespace System.Data.Entity.Objects
             return stream;
         }
 
-#if NET452
+#if NETFRAMEWORK
         private T DeserializeStringWithFormatter<T>(string base64String)
         {
             var formatter = new BinaryFormatter();
@@ -630,7 +630,7 @@ namespace System.Data.Entity.Objects
             return base64String;
         }
 
-#if NET452
+#if NETFRAMEWORK
         private T DeserializeFromBinaryFormatter<T>(T proxy)
         {
             var stream = new MemoryStream();

--- a/test/FunctionalTests/PlanCompiler/LimitExpressionTests.cs
+++ b/test/FunctionalTests/PlanCompiler/LimitExpressionTests.cs
@@ -60,7 +60,7 @@ namespace PlanCompilerTests
         private string _limit_ComplexModel_OrderBy_Skip_SingleOrDefault_expectedSql;
         private string _limit_ComplexModel_OrderBy_Skip_Take_expectedSql;
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Limit_SimpleModel_First()
         {

--- a/test/FunctionalTests/ProductivityApi/ConcurrencyTests.cs
+++ b/test/FunctionalTests/ProductivityApi/ConcurrencyTests.cs
@@ -705,7 +705,7 @@ namespace ProductivityApiTests
 
         #region Serialization of exceptions
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         [UseDefaultExecutionStrategy]
         public void DbUpdateException_can_be_serialized_but_does_not_serialize_entries()

--- a/test/FunctionalTests/ProductivityApi/DatabaseInitializationTests.cs
+++ b/test/FunctionalTests/ProductivityApi/DatabaseInitializationTests.cs
@@ -649,7 +649,7 @@ namespace ProductivityApiTests
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void CreateDatabaseIfNotExists_does_nothing_if_database_exists_without_metadata_but_with_model_table_in_nondefault_schema_ce()
         {

--- a/test/FunctionalTests/ProductivityApi/DbConnectionFactoryTests.cs
+++ b/test/FunctionalTests/ProductivityApi/DbConnectionFactoryTests.cs
@@ -26,7 +26,7 @@ namespace ProductivityApiTests
 
         #region Positive SqlCeConnectionFactory tests
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void SqlCeConnectionFactory_creates_a_SQL_CE_connection_from_a_database_name()
         {
@@ -62,7 +62,7 @@ namespace ProductivityApiTests
 
         #region Negative SqlCeConnectionFactory tests
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void SqlCeConnectionFactory_throws_when_a_connection_with_bad_database_path_is_used()
         {

--- a/test/FunctionalTests/ProductivityApi/DbContextTests.cs
+++ b/test/FunctionalTests/ProductivityApi/DbContextTests.cs
@@ -215,7 +215,7 @@ namespace ProductivityApiTests
             VerifySetsAreInitialized<SimpleModelContextWithNoData>(DbCompiledModelContents.DontMatch);
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Model_Tweaking_is_ignored_when_using_model_ctor_on_DbContext()
         {
@@ -583,7 +583,7 @@ namespace ProductivityApiTests
                 "DbContext_ConnectionStringNotFound", "NonexistentConnectionString");
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void DbContext_caches_models_for_two_providers()
         {

--- a/test/FunctionalTests/ProductivityApi/DeadlockTests.cs
+++ b/test/FunctionalTests/ProductivityApi/DeadlockTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.ProductivityApi
 {

--- a/test/FunctionalTests/ProductivityApi/HierarchyIdTests.cs
+++ b/test/FunctionalTests/ProductivityApi/HierarchyIdTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace ProductivityApiTests
 {

--- a/test/FunctionalTests/ProductivityApi/InvalidTypeTests.cs
+++ b/test/FunctionalTests/ProductivityApi/InvalidTypeTests.cs
@@ -127,7 +127,7 @@ namespace ProductivityApiTests
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Set_throws_only_when_used_if_type_derives_from_valid_type()
         {

--- a/test/FunctionalTests/ProductivityApi/SimpleScenariosForSqlCe.cs
+++ b/test/FunctionalTests/ProductivityApi/SimpleScenariosForSqlCe.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace ProductivityApiTests
 {

--- a/test/FunctionalTests/ProductivityApi/SpatialTests.cs
+++ b/test/FunctionalTests/ProductivityApi/SpatialTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace ProductivityApiTests
 {

--- a/test/FunctionalTests/ProductivityApi/TransactionTests.cs
+++ b/test/FunctionalTests/ProductivityApi/TransactionTests.cs
@@ -198,7 +198,7 @@ namespace ProductivityApiTests
             { }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [ExtendedFact(SkipForSqlAzure = true, Justification = "Unable to connect to master database with open connection on sqlAzure")]
         public void Issue1805_EntityConnection_is_not_subscribed_to_its_underlying_store_connection_event_after_it_has_been_disposed()
         {

--- a/test/FunctionalTests/Query/LinqToEntities/DefaultIfEmptyTests.cs
+++ b/test/FunctionalTests/Query/LinqToEntities/DefaultIfEmptyTests.cs
@@ -37,7 +37,7 @@ LEFT OUTER JOIN [dbo].[ArubaTasks] AS [Extent2] ON [Extent1].[Id] = [Extent2].[A
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void DefaultIfEmpty_with_null_default()
         {
@@ -110,7 +110,7 @@ LEFT OUTER JOIN  (SELECT [Extent2].[Id] AS [Id1], [Extent2].[ArubaOwner_Id] AS [
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void DefaultIfEmpty_with_explicit_default()
         {

--- a/test/FunctionalTests/Query/LinqToEntities/OrderByLiftingTests.cs
+++ b/test/FunctionalTests/Query/LinqToEntities/OrderByLiftingTests.cs
@@ -48,7 +48,7 @@ namespace System.Data.Entity.Query.LinqToEntities
             }
         }
         
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void OrderBy_ThenBy_Skip_lifted_above_type_filter()
         {

--- a/test/FunctionalTests/Query/LinqToEntities/SqlCeFunctionsTests.cs
+++ b/test/FunctionalTests/Query/LinqToEntities/SqlCeFunctionsTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Query.LinqToEntities
 {

--- a/test/FunctionalTests/Query/SpatialTests.cs
+++ b/test/FunctionalTests/Query/SpatialTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Query
 {

--- a/test/FunctionalTests/Query/SqlCeCanonicalFunctionsTests.cs
+++ b/test/FunctionalTests/Query/SqlCeCanonicalFunctionsTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Query
 {

--- a/test/FunctionalTests/Query/StoredProcedures/StoredProceduresTests.cs
+++ b/test/FunctionalTests/Query/StoredProcedures/StoredProceduresTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.Query.StoredProcedures
 {

--- a/test/FunctionalTests/SqlServerCompact/CodePlex2197.cs
+++ b/test/FunctionalTests/SqlServerCompact/CodePlex2197.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.SqlServerCompact
 {

--- a/test/FunctionalTests/SqlServerCompact/SqlGeneratorTests.cs
+++ b/test/FunctionalTests/SqlServerCompact/SqlGeneratorTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-#if NET452
+#if NETFRAMEWORK
 
 namespace System.Data.Entity.SqlServerCompact
 {

--- a/test/FunctionalTests/TestModels/ArubaModel/ArubaDatabaseSeeder.cs
+++ b/test/FunctionalTests/TestModels/ArubaModel/ArubaDatabaseSeeder.cs
@@ -117,7 +117,7 @@ namespace System.Data.Entity.TestModels.ArubaModel
                     c38_shortenum = (ArubaShortEnum)(i % 3)
                 };
 
-#if NET452
+#if NETFRAMEWORK
                 allTypes.c31_geography = DbGeography.FromText(string.Format("POINT ({0}.0 {0}.0)", i % 8), 4326);
                 allTypes.c32_geometry = DbGeometry.FromText(string.Format("POINT (1{0}.0 2{0}.0)", i % 8), 32768);
                 allTypes.c36_geometry_linestring = DbGeometry.FromText(string.Format("LINESTRING (1{0} 2{0}, 1{1} 2{0}, 1{1} 2{1}, 1{0} 2{1}, 1{0} 2{0})", i % 5 + 2, i % 5 + 4), 32768);
@@ -171,7 +171,7 @@ namespace System.Data.Entity.TestModels.ArubaModel
                         Arch = "Machine Config Architecture " + i,
                         Host = "Machine Config Host " + i,
                         Lang = "Machine Config Language " + i,
-#if NET452
+#if NETFRAMEWORK
                         Location = DbGeography.FromText(string.Format("POINT ({0}.0 {0}.0)", i), 4326),
 #endif
                         OS = "Machine Config Operating System " + i % 5,
@@ -268,7 +268,7 @@ namespace System.Data.Entity.TestModels.ArubaModel
                     Name = "Run Name" + i,
                     Purpose = i + 10,
                     Tasks = new List<ArubaTask>(),
-#if NET452
+#if NETFRAMEWORK
                     Geometry = DbGeometry.FromText(string.Format("POINT (1{0}.0 2{1}.0)", i % 8, 8 - i % 8), 32768),
 #endif
                 };

--- a/test/FunctionalTests/TestModels/FantasyModel/FantasyDatabaseSeeder.cs
+++ b/test/FunctionalTests/TestModels/FantasyModel/FantasyDatabaseSeeder.cs
@@ -329,7 +329,7 @@ namespace System.Data.Entity.TestModels.FantasyModel
                     Name = "Province2",
                 };
 
-#if NET452
+#if NETFRAMEWORK
             province1.Shape = DbGeometry.FromText("POINT(1 1)", DbGeometry.DefaultCoordinateSystemId);
             province2.Shape = DbGeometry.FromText("POINT(2 2)", DbGeometry.DefaultCoordinateSystemId);
 #endif

--- a/test/FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarDatabaseSeeder.cs
+++ b/test/FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarDatabaseSeeder.cs
@@ -90,7 +90,7 @@ namespace System.Data.Entity.TestModels.GearsOfWarModel
                 Name = "Hanover",
             };
 
-#if NET452
+#if NETFRAMEWORK
             jacinto.Location = DbGeography.FromText("POINT(1 1)", DbGeography.DefaultCoordinateSystemId);
             ephyra.Location = DbGeography.FromText("POINT(2 2)", DbGeography.DefaultCoordinateSystemId);
             hanover.Location = DbGeography.FromText("POINT(3 3)", DbGeography.DefaultCoordinateSystemId);

--- a/test/FunctionalTests/Update/TruncationTests.cs
+++ b/test/FunctionalTests/Update/TruncationTests.cs
@@ -168,7 +168,7 @@ namespace System.Data.Entity.Update
             allTypes.c12_smallmoney = value;
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void SQL_Compact_does_not_truncate_decimals_on_insert_or_update()
         {

--- a/test/FunctionalTests/Update/UpdateTests.cs
+++ b/test/FunctionalTests/Update/UpdateTests.cs
@@ -862,7 +862,7 @@ namespace System.Data.Entity.Update
                 });
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         [UseDefaultExecutionStrategy]
         public void Insert_update_delete_entity_with_spatial_property()

--- a/test/FunctionalTests/WrappingProvider/WrappingProviderTests.cs
+++ b/test/FunctionalTests/WrappingProvider/WrappingProviderTests.cs
@@ -38,7 +38,7 @@ namespace System.Data.Entity.WrappingProvider
             RegisterAdoNetProvider(typeof(SqlClientFactory));
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void Wrapping_provider_can_be_found_using_net40_style_table_lookup_even_after_first_asking_for_non_wrapped_provider()
         {
@@ -330,7 +330,7 @@ namespace System.Data.Entity.WrappingProvider
 
         private static void RegisterAdoNetProvider(Type providerFactoryType)
         {
-#if NET452
+#if NETFRAMEWORK
             var row = _providerTable.NewRow();
             row["Name"] = "SqlClient Data Provider";
             row["Description"] = ".Net Framework Data Provider for SqlServer";

--- a/test/UnitTests/Core/Metadata/Edm/AspProxyTests.cs
+++ b/test/UnitTests/Core/Metadata/Edm/AspProxyTests.cs
@@ -7,7 +7,7 @@ namespace System.Data.Entity.Core.Metadata.Edm
 
     public class AspProxyTests : TestBase
     {
-#if NET452
+#if NETFRAMEWORK
         public class TryInitializeWebAssembly
         {
             [Fact]

--- a/test/UnitTests/Core/Objects/DataClasses/RelationshipManagerTests.cs
+++ b/test/UnitTests/Core/Objects/DataClasses/RelationshipManagerTests.cs
@@ -657,7 +657,7 @@ namespace System.Data.Entity.Core.Objects.DataClasses
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         private static T SerializeAndDeserialize<T>(T instance)
         {
             var stream = new MemoryStream();

--- a/test/UnitTests/Core/Objects/Internal/EntityProxyFactoryTests.cs
+++ b/test/UnitTests/Core/Objects/Internal/EntityProxyFactoryTests.cs
@@ -21,7 +21,7 @@ namespace System.Data.Entity.Core.Objects.Internal
             Assert.NotNull(EntityWrapperFactory.CreateWrapperDelegateTypedWithoutRelationshipsMethod);
         }
 
-#if NET452
+#if NETFRAMEWORK
         public class MarkAsNotSerializable : TestBase
         {
             [Fact]

--- a/test/UnitTests/ModelConfiguration/ModelValidationExceptionTests.cs
+++ b/test/UnitTests/ModelConfiguration/ModelValidationExceptionTests.cs
@@ -47,7 +47,7 @@ namespace System.Data.Entity.ModelConfiguration
             Assert.Equal(inner, e.InnerException);
         }
 
-#if NET452
+#if NETFRAMEWORK
         internal static T BinarySerialization<T>(T obj)
         {
             IFormatter formatter = new BinaryFormatter();

--- a/test/UnitTests/SqlServer/SqlSpatialServicesTests.cs
+++ b/test/UnitTests/SqlServer/SqlSpatialServicesTests.cs
@@ -206,7 +206,7 @@ namespace System.Data.Entity.SqlServer
             Assert.Same(sqlTypesAssembly, new SqlSpatialServices(mockLoader.Object).SqlTypes);
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void SqlSpatialServices_can_be_serialized()
         {

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>System.Data.Entity</RootNamespace>
     <AssemblyName>EntityFramework.UnitTests</AssemblyName>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/UnitTests/Validation/DbEntityValidationExceptionTests.cs
+++ b/test/UnitTests/Validation/DbEntityValidationExceptionTests.cs
@@ -125,7 +125,7 @@ namespace System.Data.Entity.Validation
             }
         }
 
-#if NET452
+#if NETFRAMEWORK
         [Fact]
         public void DbEntityValidationException_serialization_and_deserialization()
         {

--- a/test/VBTests/VBTests.vbproj
+++ b/test/VBTests/VBTests.vbproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <RootNamespace />
     <AssemblyName>EntityFramework.VBTests</AssemblyName>
-    <TargetFrameworks>net452;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>net462;$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <Content Include="$(NuGetPackageRoot)microsoft.sqlserver.types\$(MicrosoftSqlServerTypesVersion)\content\readme.htm">
       <Link>SqlServerTypes\readme.htm</Link>
     </Content>


### PR DESCRIPTION
Build-ops suggestion from discussion https://github.com/dotnet/ef6/pull/2158

Context: test runner no longer supports NET452, which is being proposed by automatic updates

This:

- changes test projects to use minimum NET462 (was NET452)
- where previous test code used `#if NET452` etc, use `#if NETFRAMEWORK` instead, to make version-independent (they are not multi-targeting multiple netfx TFMs)

Note that this PR **does not** change the TFM for the actual library, which offers down to NET45
