### PR TITLE
Add fix for .NET 10 first-class span support

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>6.6.1</VersionPrefix>
+    <VersionPrefix>6.6.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <SemanticVersioningV1>True</SemanticVersioningV1>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>6.6.0</VersionPrefix>
+    <VersionPrefix>6.6.1</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <SemanticVersioningV1>True</SemanticVersioningV1>
@@ -12,7 +12,7 @@
     -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
-    <DefaultNetCoreTargetFramework>net9.0</DefaultNetCoreTargetFramework>
+    <DefaultNetCoreTargetFramework>net10.0</DefaultNetCoreTargetFramework>
   </PropertyGroup>
   <PropertyGroup Label="Dependencies from nuget.org">
     <MicrosoftBuildFrameworkVersion>16.0.461</MicrosoftBuildFrameworkVersion>

--- a/src/EntityFramework/Core/Objects/ELinq/LinqExpressionNormalizer.cs
+++ b/src/EntityFramework/Core/Objects/ELinq/LinqExpressionNormalizer.cs
@@ -7,6 +7,7 @@ namespace System.Data.Entity.Core.Objects.ELinq
     using System.Data.Entity.Utilities;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
 
@@ -124,6 +125,32 @@ namespace System.Data.Entity.Core.Objects.ELinq
                    ((ConstantExpression)expression).Value.Equals(0);
         }
 
+#if NETSTANDARD2_1
+        // <summary>
+        // Attempts to unwrap an implicit Span or ReadOnlySpan cast expression to get the underlying array or collection.
+        // This is used to rewrite MemoryExtensions methods that operate on Span/ReadOnlySpan back to Enumerable methods.
+        // </summary>
+        private static bool TryUnwrapSpanImplicitCast(Expression expression, out Expression result)
+        {
+            if (expression is MethodCallExpression methodCallExpr
+                && methodCallExpr.Method.Name == "op_Implicit"
+                && methodCallExpr.Method.DeclaringType != null
+                && methodCallExpr.Method.DeclaringType.IsGenericType
+                && methodCallExpr.Arguments.Count == 1)
+            {
+                var genericTypeDefinition = methodCallExpr.Method.DeclaringType.GetGenericTypeDefinition();
+                if (genericTypeDefinition == typeof(Span<>) || genericTypeDefinition == typeof(ReadOnlySpan<>))
+                {
+                    result = methodCallExpr.Arguments[0];
+                    return true;
+                }
+            }
+
+            result = null;
+            return false;
+        }
+#endif
+
         // <summary>
         // Handles MethodCall patterns:
         // - Operator overloads
@@ -132,6 +159,51 @@ namespace System.Data.Entity.Core.Objects.ELinq
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
         internal override Expression VisitMethodCall(MethodCallExpression m)
         {
+#if NETSTANDARD2_1
+            // .NET 10 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans").
+            // Unfortunately, the LINQ interpreter does not support ref structs, so we rewrite e.g. MemoryExtensions.Contains to
+            // Enumerable.Contains here.
+            // See:
+            //   https://github.com/dotnet/ef6/issues/2322
+            //   https://github.com/dotnet/runtime/issues/109757
+            //   https://github.com/dotnet/efcore/pull/35339
+            // Note: This check must occur before base.VisitMethodCall() to detect op_Implicit before it's normalized to Convert.
+            if (m.Method.DeclaringType == typeof(MemoryExtensions))
+            {
+                switch (m.Method.Name)
+                {
+                    // Note that MemoryExtensions.Contains has an optional 3rd ComparisonType parameter; we only match when
+                    // it's null.
+                    case nameof(MemoryExtensions.Contains)
+                        when m.Arguments.Count >= 2
+                        && (m.Arguments.Count == 2
+                            || m.Arguments.Count == 3 && m.Arguments[2] is ConstantExpression constantExpr && constantExpr.Value == null)
+                        && TryUnwrapSpanImplicitCast(m.Arguments[0], out var unwrappedSpanArg):
+                    {
+                        var containsMethod = typeof(System.Linq.Enumerable).GetMethods()
+                            .Where(method => method.Name == nameof(Enumerable.Contains) && method.GetParameters().Length == 2)
+                            .Single()
+                            .MakeGenericMethod(m.Method.GetGenericArguments()[0]);
+
+                        return Visit(Expression.Call(containsMethod, unwrappedSpanArg, m.Arguments[1]));
+                    }
+
+                    case nameof(MemoryExtensions.SequenceEqual)
+                        when m.Arguments.Count == 2
+                        && TryUnwrapSpanImplicitCast(m.Arguments[0], out var unwrappedSpanArg1)
+                        && TryUnwrapSpanImplicitCast(m.Arguments[1], out var unwrappedSpanArg2):
+                    {
+                        var sequenceEqualMethod = typeof(System.Linq.Enumerable).GetMethods()
+                            .Where(method => method.Name == nameof(Enumerable.SequenceEqual) && method.GetParameters().Length == 2)
+                            .Single()
+                            .MakeGenericMethod(m.Method.GetGenericArguments()[0]);
+
+                        return Visit(Expression.Call(sequenceEqualMethod, unwrappedSpanArg1, unwrappedSpanArg2));
+                    }
+                }
+            }
+#endif
+
             m = (MethodCallExpression)base.VisitMethodCall(m);
 
             if (m.Method.IsStatic)

--- a/src/EntityFramework/Core/Objects/ELinq/LinqExpressionNormalizer.cs
+++ b/src/EntityFramework/Core/Objects/ELinq/LinqExpressionNormalizer.cs
@@ -161,8 +161,8 @@ namespace System.Data.Entity.Core.Objects.ELinq
         {
 #if NETSTANDARD2_1
             // .NET 10 made changes to overload resolution to prefer Span-based overloads when those exist ("first-class spans").
-            // Unfortunately, the LINQ interpreter does not support ref structs, so we rewrite e.g. MemoryExtensions.Contains to
-            // Enumerable.Contains here.
+            // Unfortunately, EF6's query translator does not recognize MemoryExtensions methods, so we rewrite e.g.
+            // MemoryExtensions.Contains to Enumerable.Contains here.
             // See:
             //   https://github.com/dotnet/ef6/issues/2322
             //   https://github.com/dotnet/runtime/issues/109757

--- a/test/UnitTests/Core/Objects/ELinq/LinqExpressionNormalizerTests.cs
+++ b/test/UnitTests/Core/Objects/ELinq/LinqExpressionNormalizerTests.cs
@@ -1,8 +1,13 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 namespace System.Data.Entity.Core.Objects.ELinq
 {
     using Xunit;
+#if NET5_0_OR_GREATER
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+#endif
 
     public class LinqExpressionNormalizerTests
     {
@@ -11,5 +16,177 @@ namespace System.Data.Entity.Core.Objects.ELinq
         {
             Assert.NotNull(LinqExpressionNormalizer.RelationalOperatorPlaceholderMethod);
         }
+
+#if NET5_0_OR_GREATER
+
+        [Fact]
+        public void MemoryExtensions_Contains_with_ReadOnlySpan_is_rewritten_to_Enumerable_Contains()
+        {
+            // Test: MemoryExtensions.Contains<T>(ReadOnlySpan<T>, T)
+            var array = new[] { "Title1", "Title2", "Title3" };
+            var testValue = "Title1";
+
+            var arrayExpr = Expression.Constant(array);
+            var testValueExpr = Expression.Constant(testValue);
+
+            // Get ReadOnlySpan<T>.op_Implicit method
+            var spanType = typeof(ReadOnlySpan<>).MakeGenericType(typeof(string));
+            var implicitMethod = spanType.GetMethod("op_Implicit", new[] { typeof(string[]) });
+            var spanExpr = Expression.Call(implicitMethod, arrayExpr);
+
+            // Get MemoryExtensions.Contains<T>(ReadOnlySpan<T>, T)
+            // Note: There are both Span<T> and ReadOnlySpan<T> versions, we want ReadOnlySpan
+            var memExtContainsGeneric = typeof(MemoryExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(m => m.Name == nameof(MemoryExtensions.Contains)
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters().Length == 2
+                    && m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>))
+                .Single();
+            var memExtContains = memExtContainsGeneric.MakeGenericMethod(typeof(string));
+
+            var methodCall = Expression.Call(memExtContains, spanExpr, testValueExpr);
+
+            // Normalize the expression
+            var normalizer = new LinqExpressionNormalizer();
+            var normalized = normalizer.Visit(methodCall);
+
+            // Verify it was rewritten to Enumerable.Contains
+            var normalizedCall = Assert.IsAssignableFrom<MethodCallExpression>(normalized);
+            Assert.Equal(nameof(Enumerable.Contains), normalizedCall.Method.Name);
+            Assert.Equal(typeof(Enumerable), normalizedCall.Method.DeclaringType);
+            Assert.Equal(2, normalizedCall.Arguments.Count);
+
+            // The first argument should be the unwrapped array
+            Assert.IsAssignableFrom<ConstantExpression>(normalizedCall.Arguments[0]);
+            var unwrappedArray = ((ConstantExpression)normalizedCall.Arguments[0]).Value;
+            Assert.Same(array, unwrappedArray);
+        }
+
+        [Fact]
+        public void MemoryExtensions_Contains_with_Span_is_rewritten_to_Enumerable_Contains()
+        {
+            // Test: MemoryExtensions.Contains<T>(Span<T>, T)
+            var array = new[] { "Title1", "Title2", "Title3" };
+            var testValue = "Title1";
+
+            var arrayExpr = Expression.Constant(array);
+            var testValueExpr = Expression.Constant(testValue);
+
+            // Get Span<T>.op_Implicit method
+            var spanType = typeof(Span<>).MakeGenericType(typeof(string));
+            var implicitMethod = spanType.GetMethod("op_Implicit", new[] { typeof(string[]) });
+            var spanExpr = Expression.Call(implicitMethod, arrayExpr);
+
+            // Get MemoryExtensions.Contains<T>(Span<T>, T)
+            var memExtContainsGeneric = typeof(MemoryExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(m => m.Name == nameof(MemoryExtensions.Contains)
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters().Length == 2
+                    && m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(Span<>))
+                .Single();
+            var memExtContains = memExtContainsGeneric.MakeGenericMethod(typeof(string));
+
+            var methodCall = Expression.Call(memExtContains, spanExpr, testValueExpr);
+
+            // Normalize the expression
+            var normalizer = new LinqExpressionNormalizer();
+            var normalized = normalizer.Visit(methodCall);
+
+            // Verify it was rewritten to Enumerable.Contains
+            var normalizedCall = Assert.IsAssignableFrom<MethodCallExpression>(normalized);
+            Assert.Equal(nameof(Enumerable.Contains), normalizedCall.Method.Name);
+            Assert.Equal(typeof(Enumerable), normalizedCall.Method.DeclaringType);
+            Assert.Equal(2, normalizedCall.Arguments.Count);
+
+            // The first argument should be the unwrapped array
+            Assert.IsAssignableFrom<ConstantExpression>(normalizedCall.Arguments[0]);
+            var unwrappedArray = ((ConstantExpression)normalizedCall.Arguments[0]).Value;
+            Assert.Same(array, unwrappedArray);
+        }
+
+#if NET10_0_OR_GREATER
+        [Fact]
+        public void MemoryExtensions_Contains_with_null_comparer_is_rewritten()
+        {
+            // Test: MemoryExtensions.Contains<T>(ReadOnlySpan<T>, T, IEqualityComparer<T>) with null comparer
+            // Note: This 3-parameter overload was added in .NET 10
+            // The fix rewrites this when the comparer parameter is null
+            var array = new[] { "Title1", "Title2", "Title3" };
+            var testValue = "Title1";
+
+            var arrayExpr = Expression.Constant(array);
+            var testValueExpr = Expression.Constant(testValue);
+            var nullComparerExpr = Expression.Constant(null, typeof(System.Collections.Generic.IEqualityComparer<string>));
+
+            // Get ReadOnlySpan<T>.op_Implicit method
+            var spanType = typeof(ReadOnlySpan<>).MakeGenericType(typeof(string));
+            var implicitMethod = spanType.GetMethod("op_Implicit", new[] { typeof(string[]) });
+            var spanExpr = Expression.Call(implicitMethod, arrayExpr);
+
+            // Get MemoryExtensions.Contains<T>(ReadOnlySpan<T>, T, IEqualityComparer<T>)
+            var memExtContainsGeneric = typeof(MemoryExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(m => m.Name == nameof(MemoryExtensions.Contains)
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters().Length == 3
+                    && m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>)
+                    && m.GetParameters()[2].ParameterType.GetGenericTypeDefinition() == typeof(System.Collections.Generic.IEqualityComparer<>))
+                .Single();
+            var memExtContains = memExtContainsGeneric.MakeGenericMethod(typeof(string));
+
+            var methodCall = Expression.Call(memExtContains, spanExpr, testValueExpr, nullComparerExpr);
+
+            // Normalize the expression
+            var normalizer = new LinqExpressionNormalizer();
+            var normalized = normalizer.Visit(methodCall);
+
+            // Verify it was rewritten to Enumerable.Contains
+            var normalizedCall = Assert.IsAssignableFrom<MethodCallExpression>(normalized);
+            Assert.Equal(nameof(Enumerable.Contains), normalizedCall.Method.Name);
+            Assert.Equal(typeof(Enumerable), normalizedCall.Method.DeclaringType);
+            Assert.Equal(2, normalizedCall.Arguments.Count);
+        }
+#endif
+
+        [Fact]
+        public void MemoryExtensions_SequenceEqual_is_rewritten_to_Enumerable_SequenceEqual()
+        {
+            // Test that SequenceEqual is also rewritten correctly
+
+            var array1 = new[] { 1, 2, 3 };
+            var array2 = new[] { 1, 2, 3 };
+
+            var array1Expr = Expression.Constant(array1);
+            var array2Expr = Expression.Constant(array2);
+
+            // Get the Span<T> op_Implicit method
+            var spanType = typeof(ReadOnlySpan<>).MakeGenericType(typeof(int));
+            var implicitMethod = spanType.GetMethod("op_Implicit", new[] { typeof(int[]) });
+            var span1Expr = Expression.Call(implicitMethod, array1Expr);
+            var span2Expr = Expression.Call(implicitMethod, array2Expr);
+
+            // Get MemoryExtensions.SequenceEqual<T>(ReadOnlySpan<T>, ReadOnlySpan<T>) - the generic method with 2 parameters
+            // Note: There are both Span<T> and ReadOnlySpan<T> versions, we want ReadOnlySpan
+            var memExtSequenceEqualGeneric = typeof(MemoryExtensions).GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Where(m => m.Name == nameof(MemoryExtensions.SequenceEqual)
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters().Length == 2
+                    && m.GetParameters()[0].ParameterType.GetGenericTypeDefinition() == typeof(ReadOnlySpan<>))
+                .Single();
+            var memExtSequenceEqual = memExtSequenceEqualGeneric.MakeGenericMethod(typeof(int));
+
+            var methodCall = Expression.Call(memExtSequenceEqual, span1Expr, span2Expr);
+
+            // Normalize the expression
+            var normalizer = new LinqExpressionNormalizer();
+            var normalized = normalizer.Visit(methodCall);
+
+            // Verify it was rewritten to Enumerable.SequenceEqual
+            var normalizedCall = Assert.IsAssignableFrom<MethodCallExpression>(normalized);
+            Assert.Equal(nameof(Enumerable.SequenceEqual), normalizedCall.Method.Name);
+            Assert.Equal(typeof(Enumerable), normalizedCall.Method.DeclaringType);
+            Assert.Equal(2, normalizedCall.Arguments.Count);
+        }
+
+#endif
     }
 }

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -63,6 +63,10 @@
     <!-- Tests using System.Diagnostics.EventLog or AppDomain (incompatible with .NET Core) -->
     <Compile Remove="Infrastructure\DbExecutionStrategyTests.cs" />
     <Compile Remove="Infrastructure\Design\ForwardingProxyTests.cs" />
+
+    <!-- Tests using obsolete APIs that cause build errors in Release mode -->
+    <Compile Remove="Infrastructure\Design\ExecutorTests.cs" />
+    <Compile Remove="Migrations\Utilities\ConfigurationFileUpdaterTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -17,56 +17,14 @@
   </ItemGroup>
 
   <!--
-    Exclude .NET Framework-specific tests when building for .NET 10+
-
-    These tests depend on APIs that don't exist in .NET Core/.NET 10:
-    - System.Data.SqlServerCe (SQL Server Compact Edition provider - not ported to .NET Core)
-    - System.Runtime.Remoting (removed in .NET Core)
-    - Binary serialization (BinaryFormatter deprecated/removed in .NET 5+)
-    - System.Diagnostics.EventLog (requires separate package reference)
-
-    Future work: These tests could potentially be updated to:
-    - Use conditional compilation to skip .NET Framework-specific assertions
-    - Mock the missing APIs
-    - Be replaced with equivalent tests that work cross-platform
+    For .NET 10+ builds, only include Span-related tests. The vast majority of the UnitTests project
+    depends on .NET Framework-specific infrastructure (SqlServerCe, Remoting, BinaryFormatter, etc.)
+    and was not designed for cross-platform use. Rather than exclude hundreds of tests, we whitelist
+    only the tests relevant for .NET 10+ scenarios.
   -->
   <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">
-    <!-- Entire SqlServerCompact test directory - provider doesn't exist on .NET Core -->
-    <Compile Remove="SqlServerCompact\**\*.cs" />
-
-    <!-- Tests using System.Data.SqlServerCe or System.Runtime.Remoting -->
-    <Compile Remove="AssemblyTests.cs" />
-    <Compile Remove="Core\Mapping\EntityContainerMappingTests.cs" />
-    <Compile Remove="DbContextTests.cs" />
-    <Compile Remove="Infrastructure\DependencyResolution\AppConfigDependencyResolverTests.cs" />
-    <Compile Remove="Internal\DatabaseCreatorTests.cs" />
-    <Compile Remove="Internal\InternalConnectionTests.cs" />
-    <Compile Remove="Migrations\DbMigrationsConfiguration`Tests.cs" />
-    <Compile Remove="Migrations\DbMigratorTests.cs" />
-    <Compile Remove="Migrations\DbSetMigrationsExtensionsTests.cs" />
-    <Compile Remove="Migrations\History\HistoryRepositoryTests.cs" />
-    <Compile Remove="Migrations\Infrastructure\EdmModelDifferTests.cs" />
-    <Compile Remove="Migrations\Utilities\DatabaseCreatorTests.cs" />
-    <Compile Remove="Migrations\Utilities\EmptyContextTests.cs" />
-    <Compile Remove="SqlServer\SqlProviderManifestTests.cs" />
-    <Compile Remove="SqlServer\SqlProviderServicesTests.cs" />
-    <Compile Remove="Utilities\DbProviderInfoExtensionsTests.cs" />
-
-    <!-- Tests using binary serialization (BinaryFormatter deprecated/removed) -->
-    <Compile Remove="Core\EntitySqlExceptionTests.cs" />
-    <Compile Remove="Core\Objects\DataClasses\RelationshipManagerTests.cs" />
-    <Compile Remove="Core\PropertyConstraintExceptionTests.cs" />
-    <Compile Remove="Infrastructure\DbUpdateConcurrencyExceptionTests.cs" />
-    <Compile Remove="Infrastructure\DbUpdateExceptionTests.cs" />
-    <Compile Remove="Validation\DbEntityValidationExceptionTests.cs" />
-
-    <!-- Tests using System.Diagnostics.EventLog or AppDomain (incompatible with .NET Core) -->
-    <Compile Remove="Infrastructure\DbExecutionStrategyTests.cs" />
-    <Compile Remove="Infrastructure\Design\ForwardingProxyTests.cs" />
-
-    <!-- Tests using obsolete APIs that cause build errors in Release mode -->
-    <Compile Remove="Infrastructure\Design\ExecutorTests.cs" />
-    <Compile Remove="Migrations\Utilities\ConfigurationFileUpdaterTests.cs" />
+    <Compile Remove="**\*.cs" />
+    <Compile Include="**\LinqExpressionNormalizerTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <RootNamespace>System.Data.Entity</RootNamespace>
     <AssemblyName>EntityFramework.UnitTests</AssemblyName>
-    <TargetFramework>$(NetFrameworkToolCurrent)</TargetFramework>
+    <TargetFrameworks>$(NetFrameworkToolCurrent);$(DefaultNetCoreTargetFramework)</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -14,6 +14,55 @@
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+
+  <!--
+    Exclude .NET Framework-specific tests when building for .NET 10+
+
+    These tests depend on APIs that don't exist in .NET Core/.NET 10:
+    - System.Data.SqlServerCe (SQL Server Compact Edition provider - not ported to .NET Core)
+    - System.Runtime.Remoting (removed in .NET Core)
+    - Binary serialization (BinaryFormatter deprecated/removed in .NET 5+)
+    - System.Diagnostics.EventLog (requires separate package reference)
+
+    Future work: These tests could potentially be updated to:
+    - Use conditional compilation to skip .NET Framework-specific assertions
+    - Mock the missing APIs
+    - Be replaced with equivalent tests that work cross-platform
+  -->
+  <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">
+    <!-- Entire SqlServerCompact test directory - provider doesn't exist on .NET Core -->
+    <Compile Remove="SqlServerCompact\**\*.cs" />
+
+    <!-- Tests using System.Data.SqlServerCe or System.Runtime.Remoting -->
+    <Compile Remove="AssemblyTests.cs" />
+    <Compile Remove="Core\Mapping\EntityContainerMappingTests.cs" />
+    <Compile Remove="DbContextTests.cs" />
+    <Compile Remove="Infrastructure\DependencyResolution\AppConfigDependencyResolverTests.cs" />
+    <Compile Remove="Internal\DatabaseCreatorTests.cs" />
+    <Compile Remove="Internal\InternalConnectionTests.cs" />
+    <Compile Remove="Migrations\DbMigrationsConfiguration`Tests.cs" />
+    <Compile Remove="Migrations\DbMigratorTests.cs" />
+    <Compile Remove="Migrations\DbSetMigrationsExtensionsTests.cs" />
+    <Compile Remove="Migrations\History\HistoryRepositoryTests.cs" />
+    <Compile Remove="Migrations\Infrastructure\EdmModelDifferTests.cs" />
+    <Compile Remove="Migrations\Utilities\DatabaseCreatorTests.cs" />
+    <Compile Remove="Migrations\Utilities\EmptyContextTests.cs" />
+    <Compile Remove="SqlServer\SqlProviderManifestTests.cs" />
+    <Compile Remove="SqlServer\SqlProviderServicesTests.cs" />
+    <Compile Remove="Utilities\DbProviderInfoExtensionsTests.cs" />
+
+    <!-- Tests using binary serialization (BinaryFormatter deprecated/removed) -->
+    <Compile Remove="Core\EntitySqlExceptionTests.cs" />
+    <Compile Remove="Core\Objects\DataClasses\RelationshipManagerTests.cs" />
+    <Compile Remove="Core\PropertyConstraintExceptionTests.cs" />
+    <Compile Remove="Infrastructure\DbUpdateConcurrencyExceptionTests.cs" />
+    <Compile Remove="Infrastructure\DbUpdateExceptionTests.cs" />
+    <Compile Remove="Validation\DbEntityValidationExceptionTests.cs" />
+
+    <!-- Tests using System.Diagnostics.EventLog or AppDomain (incompatible with .NET Core) -->
+    <Compile Remove="Infrastructure\DbExecutionStrategyTests.cs" />
+    <Compile Remove="Infrastructure\Design\ForwardingProxyTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>System.Data.Entity</RootNamespace>
@@ -19,7 +19,7 @@
   <!--
     For .NET 10+ builds, only include Span-related tests. The vast majority of the UnitTests project
     depends on .NET Framework-specific infrastructure (SqlServerCe, Remoting, BinaryFormatter, etc.)
-    and was not designed for cross-platform use. Rather than exclude hundreds of tests, we whitelist
+    and was not designed for cross-platform use. Rather than exclude hundreds of tests, we include
     only the tests relevant for .NET 10+ scenarios.
   -->
   <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetCoreTargetFramework)'">


### PR DESCRIPTION
See:
- https://github.com/dotnet/ef6/issues/2322
- https://github.com/dotnet/runtime/issues/109757

This PR is as direct of a port of @roji's [original .EF Core fix](https://github.com/dotnet/efcore/pull/35339) as I could make it, with minor adjustments as required by EF6.

I added unit tests that demonstrated failure before the fix and success on all cases afterwards.

Thanks for the help hopefully getting this into EF6!
Cheers,
Eric

