### PR TITLE
Upgrade to V4 arcade publishing

### DIFF
--- a/azure-pipelines-public.yml
+++ b/azure-pipelines-public.yml
@@ -5,8 +5,6 @@ variables:
     value: AspNetCore
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
     value: true
-  - name: _PublishUsingPipelines
-    value: true
   - name: _DotNetArtifactsCategory
     value: ASPNETENTITYFRAMEWORK6
   - ${{ if ne(variables['System.TeamProject'], 'public') }}:
@@ -37,13 +35,15 @@ stages:
       parameters:
         enableMicrobuild: true
         enablePublishBuildArtifacts: true
+        publishingVersion: 4
         enablePublishBuildAssets: true
         enablePublishTestResults: true
-        enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
         enableTelemetry: true
         helixRepo: dotnet/ef6
         jobs:
           - job: Windows
+            ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+              enablePublishing: true
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngPublicBuildPool)
@@ -60,7 +60,6 @@ stages:
                 - _InternalBuildArgs: /p:DotNetSignType=$(_SignType)
                                       /p:TeamName=$(_TeamName)
                                       /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-                                      /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                                       /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
             steps:
               - checkout: self
@@ -111,6 +110,7 @@ stages:
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml
     parameters:
+      publishingInfraVersion: 4
       # Symbol validation isn't being very reliable lately. This should be enabled back
       # once this issue is resolved: https://github.com/dotnet/arcade/issues/2871
       enableSymbolValidation: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,6 @@ variables:
     value: AspNetCore
   - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
     value: true
-  - name: _PublishUsingPipelines
-    value: true
   - name: _DotNetArtifactsCategory
     value: ASPNETENTITYFRAMEWORK6
   - group: DotNet-MSRC-Storage
@@ -72,9 +70,9 @@ extends:
         parameters:
           enableMicrobuild: true
           enablePublishBuildArtifacts: true
+          publishingVersion: 4
           enablePublishBuildAssets: true
           enablePublishTestResults: true
-          enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
           enableTelemetry: true
           helixRepo: dotnet/ef6
           # WORKAROUND: BinSkim requires the folder to exist prior to scanning.
@@ -83,6 +81,8 @@ extends:
               displayName: Create artifacts/bin/$(_BuildConfig) directory
           jobs:
           - job: Windows
+            ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+              enablePublishing: true
             pool:
               name: $(DncEngInternalBuildPool)
               demands: ImageOverride -equals 1es-windows-2022
@@ -94,7 +94,7 @@ extends:
               - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
                 - _SignType: real
                 - _Sign: true
-                - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(BUILD.BUILDNUMBER) /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines) /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
+                - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(BUILD.BUILDNUMBER) /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                 - ${{ if eq(parameters.IsFinalBuild, true) }}:
                   - _AdditionalBuildArgs: /p:StabilizePackageVersion=true
               # Ignore test and infrastructure code.
@@ -141,7 +141,7 @@ extends:
     - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
       - template: /eng/common/templates-official/post-build/post-build.yml@self
         parameters:
-          publishingInfraVersion: 3
+          publishingInfraVersion: 4
           enableSigningValidation: false
           enableNugetValidation: false
           enableSourceLinkValidation: false

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,5 +1,6 @@
 <Project>
     <PropertyGroup>
+       <PublishingVersion>4</PublishingVersion>
        <ProducesDotNetReleaseShippingAssets>true</ProducesDotNetReleaseShippingAssets>
     </PropertyGroup>
  </Project>


### PR DESCRIPTION
## Summary
- switch Arcade publishing to V4
- remove obsolete V3 pipeline publishing plumbing
- update post-build validation to use V4 artifacts

Part of dotnet/arcade#16697