### PR TITLE
Remove obsolete MSRC storage variable group

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,6 @@ variables:
     value: true
   - name: _DotNetArtifactsCategory
     value: ASPNETENTITYFRAMEWORK6
-  - group: DotNet-MSRC-Storage
   - name: _InternalRuntimeDownloadArgs
     value: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
   - template: /eng/common/templates-official/variables/pool-providers.yml@self


### PR DESCRIPTION
Removes the stale DotNet-MSRC-Storage import from the EF6 pipeline.

VG25 now contains only the non-secret DummySecret placeholder, and DummySecret is not referenced by EF6. The latest successful internal/release build also ran without a resolved storage-feed key, so removing the group does not change the observed pipeline behavior.

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/10812